### PR TITLE
Update Traefik label selector in RKE2 playbook

### DIFF
--- a/ansible/rke2/default/rke2-playbook.yml
+++ b/ansible/rke2/default/rke2-playbook.yml
@@ -347,7 +347,7 @@
         kind: Pod
         namespace: kube-system
         label_selectors:
-          - app.kubernetes.io/name=traefik
+          - app.kubernetes.io/name=rke2-traefik
       register: traefik_pods
       until: >
         traefik_pods.resources | length > 0 and


### PR DESCRIPTION
Change the Traefik label selector in the RKE2 playbook to ensure proper pod identification.