### PR TITLE
revert ansible changes for k3s

### DIFF
--- a/ansible/k3s/default/ansible.cfg
+++ b/ansible/k3s/default/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
-roles_path = ../../roles
 timeout = 30
 connect_timeout = 30
 host_key_checking = False

--- a/ansible/k3s/default/roles/k3s_hardening/tasks/main.yml
+++ b/ansible/k3s/default/roles/k3s_hardening/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+- name: Validate if K3s hardening is enabled
+  set_fact:
+    hardening_enabled: >-
+      {{ (role_server_flags is defined and 'protect-kernel-defaults' in role_server_flags) or
+         (role_worker_flags is defined and 'protect-kernel-defaults' in role_worker_flags) }}
+
+- name: Ensure K3s directories exist
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0700'
+  loop:
+    - "{{ k3s_server_dir | default('/var/lib/rancher/k3s/server') }}"
+    - "{{ k3s_manifests_dir | default('/var/lib/rancher/k3s/server/manifests') }}"
+  when: k3s_node_type in ['cluster-init', 'server']
+
+- name: Apply K3s security hardening
+  when: hardening_enabled | bool
+  block:
+    - name: Apply kernel security parameters
+      sysctl:
+        name: "{{ item.key }}"
+        value: "{{ item.value }}"
+        state: present
+        reload: true
+        sysctl_file: /etc/sysctl.d/90-kubelet.conf
+      loop:
+        - { key: 'vm.panic_on_oom', value: '0' }
+        - { key: 'vm.overcommit_memory', value: '1' }
+        - { key: 'kernel.panic', value: '10' }
+        - { key: 'kernel.panic_on_oops', value: '1' }
+        - { key: 'kernel.keys.root_maxbytes', value: '25000000' }
+
+    - name: Restart systemd-sysctl service
+      systemd:
+        name: systemd-sysctl
+        state: restarted
+
+    - name: Deploy AdmissionConfiguration for CIS hardening
+      template:
+        src: admission-config-base.j2
+        dest: "{{ k3s_server_dir | default('/var/lib/rancher/k3s/server') }}/admission-config.yaml"
+        mode: '0600'
+      when: k3s_node_type in ['cluster-init', 'server']
+
+    - name: Deploy audit policy for CIS hardening
+      template:
+        src: audit-base.j2
+        dest: "{{ k3s_server_dir | default('/var/lib/rancher/k3s/server') }}/audit.yaml"
+        mode: '0600'
+      when: k3s_node_type in ['cluster-init', 'server']
+
+    - name: Create CIS server configuration
+      template:
+        src: cis-server-config-base.j2
+        dest: "{{ k3s_server_dir | default('/var/lib/rancher/k3s/server') }}/cis_server_config.yaml"
+        mode: '0600'
+      when: k3s_node_type in ['cluster-init', 'server']
+
+    - name: Create network policy manifest
+      template:
+        src: policy-base.j2
+        dest: "{{ k3s_manifests_dir | default('/var/lib/rancher/k3s/server/manifests') }}/policy.yaml"
+        mode: '0644'
+      when: k3s_node_type in ['cluster-init', 'server']
+
+    - name: Append Traefik policies to network policy manifest
+      blockinfile:
+        path: "{{ k3s_manifests_dir | default('/var/lib/rancher/k3s/server/manifests') }}/policy.yaml"
+        block: "{{ lookup('template', 'traefik-policies.j2') }}"
+        marker: "# {mark} TRAEFIK POLICIES"
+      when: 
+        - k3s_node_type in ['cluster-init', 'server']
+        - role_server_flags is not defined or 'disable-traefik' not in role_server_flags
+
+    - name: Create ingress policy manifest
+      template:
+        src: ingresspolicy-base.j2
+        dest: "{{ k3s_manifests_dir | default('/var/lib/rancher/k3s/server/manifests') }}/ingresspolicy.yaml"
+        mode: '0644'
+      when: k3s_node_type in ['cluster-init', 'server']
+
+- name: Show hardening status
+  debug:
+    msg: |
+      K3s Security Hardening: {{ 'ENABLED' if hardening_enabled else 'DISABLED' }}
+      Node Type: {{ k3s_node_type }}
+      Protect Kernel Defaults: {{ 'YES' if hardening_enabled else 'NO' }}
+      {% if not hardening_enabled %}
+      {% endif %}

--- a/ansible/k3s/default/roles/k3s_hardening/templates/admission-config-base.j2
+++ b/ansible/k3s/default/roles/k3s_hardening/templates/admission-config-base.j2
@@ -1,0 +1,68 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+  - name: EventRateLimit
+    configuration:
+      apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+      kind: Configuration
+      limits:
+        - type: Server
+          qps: 50
+          burst: 100
+        - type: Namespace
+          qps: 10
+          burst: 20
+        - type: User
+          qps: 10
+          burst: 20
+  - name: PodSecurity
+    configuration:
+      apiVersion: pod-security.admission.config.k8s.io/v1
+      kind: PodSecurityConfiguration
+      defaults:
+        enforce: "restricted"
+        enforce-version: "latest"
+        audit: "restricted"
+        audit-version: "latest"
+        warn: "restricted"
+        warn-version: "latest"
+      exemptions:
+        usernames: []
+        runtimeClasses: []
+        namespaces: [calico-apiserver,
+                     calico-system,
+                     cattle-alerting,
+                     cattle-csp-adapter-system,
+                     cattle-epinio-system,
+                     cattle-externalip-system,
+                     cattle-fleet-local-system,
+                     cattle-fleet-system,
+                     cattle-gatekeeper-system,
+                     cattle-global-data,
+                     cattle-global-nt,
+                     cattle-impersonation-system,
+                     cattle-istio,
+                     cattle-istio-system,
+                     cattle-logging,
+                     cattle-logging-system,
+                     cattle-monitoring-system,
+                     cattle-neuvector-system,
+                     cattle-prometheus,
+                     cattle-sriov-system,
+                     cattle-system,
+                     cattle-ui-plugin-system,
+                     cattle-windows-gmsa-system,
+                     cattle-provisioning-capi-system,
+                     cert-manager,
+                     cis-operator-system,
+                     fleet-default,
+                     ingress-nginx,
+                     istio-system,
+                     kube-node-lease,
+                     kube-public,
+                     kube-system,
+                     longhorn-system,
+                     rancher-alerting-drivers,
+                     security-scan,
+                     tigera-operator,
+                     sr-operator-system]

--- a/ansible/k3s/default/roles/k3s_hardening/templates/audit-base.j2
+++ b/ansible/k3s/default/roles/k3s_hardening/templates/audit-base.j2
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: "{{ audit_level | default('Metadata') }}"

--- a/ansible/k3s/default/roles/k3s_hardening/templates/cis-server-config-base.j2
+++ b/ansible/k3s/default/roles/k3s_hardening/templates/cis-server-config-base.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cis-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    # CIS benchmark configuration
+    version: cis-1.6
+    target: master
+    controls:
+      skip:
+        - 1.1.12  # Ensure that the etcd data directory permissions are set to 700 or more restrictive
+        - 1.1.13  # Ensure that the etcd data directory ownership is set to etcd:etcd

--- a/ansible/k3s/default/roles/k3s_hardening/templates/ingresspolicy-base.j2
+++ b/ansible/k3s/default/roles/k3s_hardening/templates/ingresspolicy-base.j2
@@ -1,0 +1,15 @@
+---
+# Traefik Ingress Policy for K3s K3S_VERSION_PLACEHOLDER
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-traefik-v121-ingress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  ingress:
+    - {}
+  policyTypes:
+    - Ingress

--- a/ansible/k3s/default/roles/k3s_hardening/templates/policy-base.j2
+++ b/ansible/k3s/default/roles/k3s_hardening/templates/policy-base.j2
@@ -1,0 +1,72 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-network-dns-policy
+  namespace: kube-system
+spec:
+  ingress:
+    - ports:
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+  podSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  policyTypes:
+    - Ingress
+
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: intra-namespace
+  namespace: kube-system
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: kube-system
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: intra-namespace
+  namespace: default
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: default
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: intra-namespace
+  namespace: kube-public
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: kube-public
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-metrics-server
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: metrics-server
+  ingress:
+    - {}
+  policyTypes:
+    - Ingress

--- a/ansible/k3s/default/roles/k3s_hardening/templates/traefik-policies.j2
+++ b/ansible/k3s/default/roles/k3s_hardening/templates/traefik-policies.j2
@@ -1,0 +1,47 @@
+---
+# Traefik-specific network policies (only applied if Traefik is not disabled)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-svclbtraefik-ingress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      svccontroller.k3s.cattle.io/svcname: traefik
+  ingress:
+    - {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-traefik-v121-ingress
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  ingress:
+    - {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-to-backends
+  namespace: default
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+  policyTypes:
+    - Ingress

--- a/ansible/k3s/default/roles/k3s_install/handlers/main.yml
+++ b/ansible/k3s/default/roles/k3s_install/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+- name: restart k3s
+  raw: |
+    systemctl daemon-reload
+    systemctl restart k3s
+  listen: restart k3s
+  changed_when: true
+
+- name: restart k3s-agent
+  raw: |
+    systemctl daemon-reload
+    systemctl restart k3s-agent
+  listen: restart k3s-agent
+  changed_when: true
+

--- a/ansible/k3s/default/roles/k3s_install/tasks/k3s_registry.yaml
+++ b/ansible/k3s/default/roles/k3s_install/tasks/k3s_registry.yaml
@@ -1,0 +1,21 @@
+---
+mirrors:
+  docker.io:
+    endpoint:
+      - "https://10.115.253.191.sslip.io"
+    rewrite:
+      "^(.*)": "dockercache/$1"
+  ghcr.io:
+    endpoint:
+      - "https://10.115.253.191.sslip.io"
+    rewrite:
+      "^(.*)": "ghcrcache/$1"
+  quay.io:
+    endpoint:
+      - "https://10.115.253.191.sslip.io"
+    rewrite:
+      "^(.*)": "quaycache/$1"
+configs:
+  "10.115.253.191.sslip.io":
+    tls:
+      insecure_skip_verify: true

--- a/ansible/k3s/default/roles/k3s_install/tasks/main.yml
+++ b/ansible/k3s/default/roles/k3s_install/tasks/main.yml
@@ -1,0 +1,177 @@
+---
+- name: Validate input parameters
+  assert:
+    that:
+      - kubernetes_version is regex('^[a-zA-Z0-9.+_-]+$')
+      - k3s_channel is match("^(stable|testing|latest|v\\d+(\\.\\d+){0,2})$")  
+    fail_msg: "Invalid k3s_channel '{{ k3s_channel }}'. Must be stable, testing, latest, or v1[.x][.y]"
+
+- name: Create K3s directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0700'
+  loop:
+    - /etc/rancher/k3s
+    - "{{ k3s_server_dir | default('/var/lib/rancher/k3s/server') }}/logs"
+
+- name: Create hardening supporting directories only if hardening is enabled
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0700'
+  loop:
+    - "{{ k3s_server_dir | default('/var/lib/rancher/k3s/server') }}"
+
+- name: Generate K3s configuration from template
+  template:
+    src: k3s-config.yaml.j2
+    dest: /etc/rancher/k3s/config.yaml
+    mode: '0644'
+    backup: true
+
+- name: Check if k3s_registry.yaml exists in role files
+  ansible.builtin.stat:
+    path: "{{ role_path }}/files/k3s_registry.yaml"
+  register: registry_file
+
+- name: Ensure destination directory for registry exists
+  ansible.builtin.file:
+    path: /etc/rancher/k3s/
+    state: directory
+    mode: '0700'
+  when: registry_file.stat.exists
+
+- name: Copy k3s_registry.yaml to the registry filepath
+  ansible.builtin.copy:
+    src: "{{ role_path }}/files/k3s_registry.yaml"
+    mode: '0644'
+    dest: /etc/rancher/k3s/registries.yaml
+  when: registry_file.stat.exists
+
+- name: Download and install K3s
+  shell: |
+    # Skip installation if K3s is already installed
+    if [ -f /usr/local/bin/k3s ]; then
+      echo "K3s already installed, skipping"
+      exit 0
+    fi
+    
+    # Set installation variables - detect if version is a commit hash or version tag
+    VERSION="{{ kubernetes_version }}"
+    if [[ "$VERSION" =~ ^[0-9a-f]{40}$ ]]; then
+      echo "Installing K3s from commit: $VERSION"
+      export INSTALL_K3S_COMMIT="$VERSION"
+    else
+      echo "Installing K3s version: $VERSION"
+      export INSTALL_K3S_VERSION="$VERSION"
+    fi
+    
+    {% if k3s_channel is defined and k3s_channel != '' %}
+    export INSTALL_K3S_CHANNEL="{{ k3s_channel }}"
+    {% endif %}
+    {% if k3s_node_type == 'agent' %}
+    export INSTALL_K3S_EXEC="agent"
+    {% endif %}
+    export INSTALL_K3S_SKIP_START="true"
+    
+    # Download and install K3s
+    curl -sfL https://get.k3s.io | sh -
+  register: k3s_install_result
+  changed_when: "'K3s already installed' not in k3s_install_result.stdout"
+  args:
+    executable: bash
+
+- name: Enable and start K3s service
+  block:
+    - name: Enable and start K3s service
+      systemd:
+        name: "{{ 'k3s-agent' if k3s_node_type == 'agent' else 'k3s' }}"
+        state: "{{ k3s_service_state | default('started') }}"
+        enabled: "{{ k3s_service_enabled | default(true) }}"
+        daemon_reload: true
+
+    - name: Wait for K3s service to be ready
+      wait_for:
+        port: "{{ 6443 if k3s_node_type in ['cluster-init', 'server'] else 10250 }}"
+        host: "127.0.0.1"
+        timeout: 300
+      when: (k3s_service_state | default('started')) == 'started'
+
+  rescue:
+    - name: Display K3s debugging information
+      debug:
+        msg: |
+          K3s Service Debugging Information:
+          Service: {{ 'k3s-agent' if k3s_node_type == 'agent' else 'k3s' }}
+          Status: {{ ansible_facts.services[('k3s-agent' if k3s_node_type == 'agent' else 'k3s')].state | default('unknown') }}
+          
+    - name: Verify K3s service health
+      systemd:
+        name: "{{ 'k3s' if k3s_node_type != 'agent' else 'k3s-agent' }}"
+      register: service_status
+      
+    - name: Wait for node readiness
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig_path }}"
+        api_version: v1
+        kind: Node
+        name: "{{ inventory_hostname }}"
+      until: node_status.resources[0].status.conditions[0].type == "Ready"
+
+    - name: Get service logs
+      shell: journalctl -u {{ 'k3s-agent' if k3s_node_type == 'agent' else 'k3s' }} --no-pager -n 50
+      register: service_logs
+      
+    - name: Display service logs
+      debug:
+        var: service_logs.stdout_lines
+        
+    - name: Fail with detailed error information
+      fail:
+        msg: |
+          K3s service failed to start.
+          Service: {{ 'k3s-agent' if k3s_node_type == 'agent' else 'k3s' }}
+          Status: {{ service_status.status.ActiveState | default('unknown') }}
+
+- name: Set kubeconfig server address (cluster-init only)
+  lineinfile:
+    path: /etc/rancher/k3s/k3s.yaml
+    regexp: '^\s*server:\s*.*$'
+    line: "    server: https://{{ k3s_fqdn | default(k3s_api_host, true) }}:6443"
+    backrefs: false
+  when:
+    - k3s_node_type == 'cluster-init'
+
+- name: Check if K3s PKI directory exists
+  stat:
+    path: "{{ k3s_server_dir | default('/var/lib/rancher/k3s/server') }}/tls"
+  register: k3s_pki_dir
+  when: k3s_node_type in ['cluster-init', 'server']
+
+- name: Restrict K3s PKI certificates to 600 only if hardening is enabled (CIS 1.1.20)
+  file:
+    path: "{{ item }}"
+    mode: '0600'
+  with_fileglob:
+    - "{{ k3s_server_dir | default('/var/lib/rancher/k3s/server') }}/tls/*.crt"
+    - "{{ k3s_server_dir | default('/var/lib/rancher/k3s/server') }}/tls/*.key"
+  when:
+    - k3s_node_type in ['cluster-init', 'server']
+    - k3s_pki_dir.stat.exists | default(false)
+
+- name: Check K3s installation
+  command: /usr/local/bin/k3s --version
+  register: k3s_version_output
+  changed_when: false
+  failed_when: k3s_version_output.rc != 0
+
+- name: Show K3s installation success
+  debug:
+    msg: |
+      Version: {{ k3s_version_output.stdout.split('\n')[0] }}
+      Node Type: {{ k3s_node_type }}
+      Service: {{ 'k3s-agent' if k3s_node_type == 'agent' else 'k3s' }}
+

--- a/ansible/k3s/default/roles/k3s_install/templates/k3s-config.yaml.j2
+++ b/ansible/k3s/default/roles/k3s_install/templates/k3s-config.yaml.j2
@@ -1,0 +1,133 @@
+# K3s Configuration
+
+# Only servers/cluster-init should set write-kubeconfig-mode (agent doesn't accept it)
+{% if k3s_node_type in ['cluster-init', 'server'] %}
+write-kubeconfig-mode: "0644"
+{% endif %}
+
+# Node labels and taints based on role combinations (matching RKE2 logic)
+{% set has_etcd = 'etcd' in (ansible_role | default('')) %}
+{% set has_cp = 'cp' in (ansible_role | default('')) %}
+{% set has_worker = 'worker' in (ansible_role | default('')) %}
+
+{% if not has_etcd and has_cp and not has_worker %}
+# Control plane only node
+node-taint:
+  - node-role.kubernetes.io/control-plane:NoSchedule
+node-label:
+  - role-control-plane=true
+{% elif not has_etcd and has_cp and has_worker %}
+# Control plane + worker node
+node-label:
+  - role-control-plane=true
+  - role-worker=true
+{% elif has_etcd and has_cp and not has_worker %}
+# ETCD + control plane node
+node-taint:
+  - node-role.kubernetes.io/control-plane:NoSchedule
+  - node-role.kubernetes.io/etcd:NoExecute
+node-label:
+  - role-etcd=true
+  - role-control-plane=true
+{% elif has_etcd and has_worker and not has_cp %}
+# ETCD + worker node
+node-label:
+  - role-etcd=true
+  - role-worker=true
+{% elif has_etcd and not has_cp and not has_worker %}
+# ETCD only node
+node-taint:
+  - node-role.kubernetes.io/etcd:NoExecute
+node-label:
+  - role-etcd=true
+{% elif k3s_node_type == 'agent' %}
+# Worker-only node
+node-label:
+  - role-worker=true
+{% else %}
+# Default: all roles
+node-label:
+  - role-etcd=true
+  - role-control-plane=true
+  - role-worker=true
+{% endif %}
+
+# Node type specific configuration
+{% if k3s_node_type == 'cluster-init' %}
+cluster-init: true
+{% elif k3s_node_type == 'server' and (kube_api_host | default(k3s_api_host) | default('')) != '' %}
+server: "https://{{ kube_api_host | default(k3s_api_host) }}:6443"
+{% if k3s_token | default('') | trim %}
+token: "{{ k3s_token }}"
+{% endif %}
+{% elif k3s_node_type == 'agent' and (kube_api_host | default(k3s_api_host) | default('')) != '' %}
+server: "https://{{ kube_api_host | default(k3s_api_host) }}:6443"
+{% if k3s_token | default('') | trim %}
+token: "{{ k3s_token }}"
+{% endif %}
+{% endif %}
+
+# Advertise public/external IP to the cluster (used by kubelet/kube-proxy)
+{% if public_ip is defined and public_ip | trim != '' %}
+node-external-ip:
+  - "{{ public_ip }}"
+{% endif %}
+
+# TLS SAN entries for comprehensive certificate validity (servers only)
+{% if k3s_node_type in ['cluster-init', 'server'] %}
+tls-san:
+  - "{{ fqdn | default(k3s_fqdn) | default('localhost') }}"
+  - "{{ kube_api_host | default(k3s_api_host) | default('127.0.0.1') }}"
+  - "{{ public_ip | default('127.0.0.1') }}"
+  - "{{ ansible_host | default('127.0.0.1') }}"
+  - "{{ inventory_hostname }}"
+  - "localhost"
+  - "127.0.0.1"
+{% endif %}
+
+# Server flags (render only if provided and node is server/cluster-init)
+{% if k3s_node_type in ['cluster-init', 'server'] %}
+{% if server_flags is defined and server_flags | trim %}
+{{ server_flags }}
+{% elif role_server_flags is defined and role_server_flags | trim %}
+{{ role_server_flags }}
+{% endif %}
+{% endif %}
+
+# Worker flags (render only if provided and node is agent)
+{% if k3s_node_type == 'agent' %}
+{% if worker_flags is defined and worker_flags | trim %}
+{{ worker_flags }}
+{% elif role_worker_flags is defined and role_worker_flags | trim %}
+{{ role_worker_flags }}
+{% endif %}
+{% endif %}
+
+# CIS hardening configuration
+{% set is_hardening_enabled = (server_flags is defined and 'protect-kernel-defaults' in server_flags) or (role_server_flags is defined and 'protect-kernel-defaults' in role_server_flags) %}
+{% if is_hardening_enabled and k3s_node_type in ['cluster-init', 'server'] %}
+secrets-encryption: true
+kube-apiserver-arg:
+  - "enable-admission-plugins=NodeRestriction,EventRateLimit,PodSecurity"
+  - "admission-control-config-file=/var/lib/rancher/k3s/server/admission-config.yaml"
+  - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
+  - "audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml"
+  - "audit-log-maxage=30"
+  - "audit-log-maxbackup=10"
+  - "audit-log-maxsize=100"
+  - "service-account-extend-token-expiration=false"
+
+kube-controller-manager-arg:
+  - "terminated-pod-gc-threshold=100"
+
+kubelet-arg:
+  - "streaming-connection-idle-timeout=5m"
+  - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+
+{% elif k3s_node_type == 'agent' %}
+# Agent kubelet configuration
+kubelet-arg:
+  - "streaming-connection-idle-timeout=5m"
+  - "make-iptables-util-chains=true"
+  - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+{% endif %}

--- a/ansible/k3s/default/roles/setup/tasks/main.yml
+++ b/ansible/k3s/default/roles/setup/tasks/main.yml
@@ -1,0 +1,111 @@
+---
+- name: Check python3 version
+  raw: |
+    if command -v /usr/bin/python3 >/dev/null 2>&1; then
+      v="$(/usr/bin/python3 -V 2>&1 | awk '{print $2}')"
+      maj="${v%%.*}"; rest="${v#*.}"; min="${rest%%.*}"
+      echo "${maj:-0}.${min:-0}"
+    else
+      echo "0.0"
+    fi
+  register: pyver
+  changed_when: false
+
+- name: Detect OS family
+  raw: |
+    . /etc/os-release
+    echo "${ID}|${ID_LIKE}|${VERSION_ID}"
+  register: osr
+  changed_when: false
+
+- name: Set OS facts
+  set_fact:
+    _os_id:   "{{ (osr.stdout | default('||')).split('|')[0] | lower }}"
+    _os_like: "{{ (osr.stdout | default('||')).split('|')[1] | lower }}"
+    _os_ver:  "{{ (osr.stdout | default('||')).split('|')[2] }}"
+
+- name: Debian/Ubuntu | Ensure Python3 (>=3.8) is installed
+  raw: >
+    bash -c "set -e;
+    export DEBIAN_FRONTEND=noninteractive;
+    apt-get update;
+    apt-get install -y python3"
+  when: 
+    - (_os_id in ['debian','ubuntu'])
+    - (pyver.stdout is version('3.8', '<'))
+
+- name: RHEL-family | ensure python39 (or python3)
+  raw: |
+    set -e
+    if command -v dnf >/dev/null 2>&1; then
+      dnf -y module enable python39 || true
+      dnf -y install python39 || dnf -y install python3
+    else
+      yum -y install python39 || yum -y install python3
+    fi
+  when: 
+    - (_os_id in ['rhel','centos','rocky','almalinux','ol'] or 'rhel' in _os_like)
+    - (pyver.stdout is version('3.8', '<'))
+
+- name: SUSE/SLES | ensure python311
+  raw: |
+    set -e
+    zypper -n refresh || true
+    zypper -n install -y python311 || true
+  when: 
+    - (_os_id in ['sles','suse','opensuse-leap','opensuse'] or 'suse' in _os_like)
+    - (pyver.stdout is version('3.8', '<'))
+
+- name: Discover best Python interpreter path
+  raw: |
+    for p in /usr/bin/python3.12 /usr/bin/python3.11 /usr/bin/python311 /usr/bin/python3.10 /usr/bin/python3.9 /usr/bin/python39; do
+      if [ -x "$p" ]; then
+        echo "$p"
+        exit 0
+      fi
+    done
+    if [ -x /usr/bin/python3 ]; then
+      echo /usr/bin/python3
+      exit 0
+    fi
+    echo /usr/bin/python3
+  register: pywhich
+  changed_when: false
+
+- name: Bind Ansible to the discovered interpreter
+  set_fact:
+    ansible_python_interpreter: "{{ pywhich.stdout | trim }}"
+
+- name: Reset SSH connection to apply interpreter
+  meta: reset_connection
+
+# --- NetworkManager prep (RHEL/OL 8+) ---
+- name: Disable NetworkManager cloud setup services
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+    masked: false
+  loop:
+    - nm-cloud-setup.service
+    - nm-cloud-setup.timer
+  when:
+    - _os_id in ['rhel','centos','rocky','almalinux','ol'] or 'rhel' in _os_like
+    - (_os_ver | default('0')) is match('^([8-9]|1[0-9])')
+
+- name: Ensure CNI interfaces are unmanaged by NetworkManager
+  ansible.builtin.copy:
+    dest: /etc/NetworkManager/conf.d/99-cni.conf
+    mode: "0644"
+    owner: root
+    group: root
+    content: |
+      [keyfile]
+      unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:flannel*
+  when: _os_id in ['rhel','centos','rocky','almalinux','ol'] or 'rhel' in _os_like
+
+- name: Reload NetworkManager to pick up conf changes
+  ansible.builtin.systemd:
+    name: NetworkManager
+    state: restarted
+  when: _os_id in ['rhel','centos','rocky','almalinux','ol'] or 'rhel' in _os_like


### PR DESCRIPTION
k3s is essentially skipping the install step after the latest role updates. this is blocking harvester nightly jobs. Putting this PR up for now unless we can find a better fix.

For more context, Dan took a look at the job for a few days to try and fix the roles issues. 

tested locally and have no issues now. However GH is intermittently down right now so I can't run jenkins. 