### PR TITLE
introduce go versioning to import to other go projects

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -23,3 +23,19 @@ Before running a playbook, ensure you have the following:
     ```
 
     **Note:** you may need to add the flag `--break-system-packages` if not using a venv
+
+## Building for GO
+
+Package ansible provides embedded Ansible playbooks, roles, and configuration
+files from the qa-infra-automation repository.
+
+Usage:
+
+`import "github.com/rancher/qa-infra-automation/ansible"`
+
+Files is an embed.FS containing all Ansible content.
+Paths are relative, e.g. "roles/k3s_install/tasks/main.yml",
+"rke2/default/rke2-playbook.yml", etc.
+
+`fs.WalkDir(ansible.Files, ".", func(path string, d fs.DirEntry, err error) error { ... })`
+

--- a/ansible/embed.go
+++ b/ansible/embed.go
@@ -1,0 +1,10 @@
+package ansible
+
+import "embed"
+
+// Files contains all Ansible playbooks, roles, inventories, and configuration.
+// Use [github.com/rancher/qa-infra-automation/fsutil.WriteToDisk] to extract
+// these files to a temporary directory before running ansible-playbook.
+//
+//go:embed all:chaos all:k3s all:rancher all:rke2 all:roles ansible.cfg vars.yaml
+var Files embed.FS

--- a/fsutil/fsutil.go
+++ b/fsutil/fsutil.go
@@ -1,0 +1,60 @@
+package fsutil
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// WriteToDisk extracts all files from an [fs.FS] into the given destination
+// directory, preserving the directory structure. It creates directories as
+// needed with mode 0755 and writes files with mode 0644.
+func WriteToDisk(fsys fs.FS, destDir string) error {
+	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("walking %s: %w", path, err)
+		}
+
+		target := filepath.Join(destDir, path)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+
+		data, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return fmt.Errorf("reading embedded file %s: %w", path, err)
+		}
+
+		return os.WriteFile(target, data, 0644)
+	})
+}
+
+// WriteToDiskTemp creates a temporary directory with the given pattern and
+// extracts all files from the [fs.FS] into it. The caller is responsible for
+// removing the directory when done (typically via defer os.RemoveAll(dir)).
+func WriteToDiskTemp(fsys fs.FS, pattern string) (string, error) {
+	dir, err := os.MkdirTemp("", pattern)
+	if err != nil {
+		return "", fmt.Errorf("creating temp directory: %w", err)
+	}
+
+	if err := WriteToDisk(fsys, dir); err != nil {
+		os.RemoveAll(dir) // clean up on failure
+		return "", err
+	}
+
+	return dir, nil
+}
+
+// WriteSubdirToDisk extracts a subdirectory from an [fs.FS] into the given
+// destination directory. This is useful when you only need a specific subset
+// of the embedded files.
+func WriteSubdirToDisk(fsys fs.FS, subdir string, destDir string) error {
+	sub, err := fs.Sub(fsys, subdir)
+	if err != nil {
+		return fmt.Errorf("accessing subdirectory %s: %w", subdir, err)
+	}
+	return WriteToDisk(sub, destDir)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rancher/qa-infra-automation
+
+go 1.25.5

--- a/tofu/README.md
+++ b/tofu/README.md
@@ -1,0 +1,12 @@
+
+# Building Tofu for GO
+
+Usage:
+
+`import "github.com/rancher/qa-infra-automation/tofu"`
+
+Files is an embed.FS containing all Tofu/Terraform modules.
+Paths are relative, e.g. "aws/modules/cluster_nodes/main.tf",
+"harvester/modules/vm/main.tf", etc.
+
+`fs.WalkDir(tofu.Files, ".", func(path string, d fs.DirEntry, err error) error { ... })`

--- a/tofu/embed.go
+++ b/tofu/embed.go
@@ -1,0 +1,16 @@
+package tofu
+
+import "embed"
+
+// Files contains all OpenTofu/Terraform modules organized by provider
+// (aws, gcp, harvester, rancher). Use [github.com/rancher/qa-infra-automation/fsutil.WriteToDisk]
+// to extract these files to a directory before running tofu/terraform commands.
+//
+// The embed directive intentionally omits the "all:" prefix so that
+// .terraform/ and .terraform.lock.hcl files are excluded. Note that
+// untracked non-dot files (e.g. terraform.tfstate.d/, *.tfvars) that exist
+// locally will still be embedded during local builds. When consumed via
+// "go get" (the Go module proxy), only git-tracked files are included.
+//
+//go:embed aws gcp harvester rancher
+var Files embed.FS


### PR DESCRIPTION
this is in coordination with the effort to use qa-infra-automation in rancher/tests
https://github.com/rancher/tests/pull/552
