### PR TITLE
 Exploratory testing for Elemental and Rancher Manager interoperability

### DIFF
--- a/ansible/rancher/downstream/elemental/libvirt/elemental-playbook.yml
+++ b/ansible/rancher/downstream/elemental/libvirt/elemental-playbook.yml
@@ -35,6 +35,18 @@
         state: present
         update_cache: yes
 
+    - name: Install libvirt-daemon-system
+      ansible.builtin.apt:
+        name: libvirt-daemon-system
+        state: present
+        update_cache: yes
+
+    - name: Install libvirt-clients
+      ansible.builtin.apt:
+        name: libvirt-clients
+        state: present
+        update_cache: yes
+
     - name: Creating Elemental VM
       ansible.builtin.shell: | 
         sudo virt-install \

--- a/ansible/rancher/downstream/elemental/libvirt/elemental-playbook.yml
+++ b/ansible/rancher/downstream/elemental/libvirt/elemental-playbook.yml
@@ -29,21 +29,12 @@
         - hostvars['localhost'].download_url.stdout | length > 0
       retries: 3
 
-    - name: Install virt-manager
+    - name: Install libvirt packages
       ansible.builtin.apt:
-        name: virt-manager
-        state: present
-        update_cache: yes
-
-    - name: Install libvirt-daemon-system
-      ansible.builtin.apt:
-        name: libvirt-daemon-system
-        state: present
-        update_cache: yes
-
-    - name: Install libvirt-clients
-      ansible.builtin.apt:
-        name: libvirt-clients
+        name:
+          - virt-manager
+          - libvirt-daemon-system
+          - libvirt-clients
         state: present
         update_cache: yes
 

--- a/ansible/rancher/downstream/elemental/libvirt/elemental-playbook.yml
+++ b/ansible/rancher/downstream/elemental/libvirt/elemental-playbook.yml
@@ -32,9 +32,9 @@
     - name: Install libvirt packages
       ansible.builtin.apt:
         name:
-          - virt-manager
-          - libvirt-daemon-system
-          - libvirt-clients
+          - virt-manager=1:4.0.0-1
+          - libvirt-daemon-system=8.0.0-1ubuntu7.15
+          - libvirt-clients=8.0.0-1ubuntu7.15
         state: present
         update_cache: yes
 

--- a/ansible/rancher/downstream/elemental/libvirt/elemental-playbook.yml
+++ b/ansible/rancher/downstream/elemental/libvirt/elemental-playbook.yml
@@ -32,9 +32,9 @@
     - name: Install libvirt packages
       ansible.builtin.apt:
         name:
-          - virt-manager=1:4.0.0-1
-          - libvirt-daemon-system=8.0.0-1ubuntu7.15
-          - libvirt-clients=8.0.0-1ubuntu7.15
+          - virt-manager=1:5.1.0-1
+          - libvirt-daemon-system=11.6.0-1ubuntu3.3
+          - libvirt-clients=11.6.0-1ubuntu3.3
         state: present
         update_cache: yes
 

--- a/ansible/rancher/downstream/elemental/libvirt/elementalconfig.yaml
+++ b/ansible/rancher/downstream/elemental/libvirt/elementalconfig.yaml
@@ -2,58 +2,58 @@
 apiVersion: elemental.cattle.io/v1beta1
 kind: MachineInventorySelectorTemplate
 metadata:
-name: fire-machine-selector
-namespace: fleet-default
+  name: fire-machine-selector
+  namespace: fleet-default
 spec:
-template:
+  template:
     spec:
-    selector:
+      selector:
         matchExpressions:
-        - key: element
+          - key: element
             operator: In
-            values: [ 'fire' ]
+            values: ['fire']
 ---
 kind: Cluster
 apiVersion: provisioning.cattle.io/v1
 metadata:
-name: elemental-cluster
-namespace: fleet-default
+  name: elemental-cluster
+  namespace: fleet-default
 spec:
-rkeConfig:
+  rkeConfig:
     chartValues:
-    rke2-calico: {}
+      rke2-calico: {}
     dataDirectories:
-    k8sDistro: ''
-    provisioning: ''
-    systemAgent: ''
+      k8sDistro: ''
+      provisioning: ''
+      systemAgent: ''
     etcd:
-    disableSnapshots: false
-    snapshotRetention: 5
-    snapshotScheduleCron: 0 */5 * * *
+      disableSnapshots: false
+      snapshotRetention: 5
+      snapshotScheduleCron: 0 */5 * * *
     machineGlobalConfig:
-    cni: calico
-    disable-kube-proxy: false
-    etcd-expose-metrics: false
+      cni: calico
+      disable-kube-proxy: false
+      etcd-expose-metrics: false
     machinePools:
     - controlPlaneRole: true
-        drainBeforeDelete: true
-        etcdRole: true
-        machineConfigRef:
+      drainBeforeDelete: true
+      etcdRole: true
+      machineConfigRef:
         apiVersion: elemental.cattle.io/v1beta1
         kind: MachineInventorySelectorTemplate
         name: fire-machine-selector
-        name: fire-pool
-        quantity: 1
-        unhealthyNodeTimeout: 0s
-        workerRole: true
-        hostnamePrefix: elemental-cluster-fire-pool-
+      name: fire-pool
+      quantity: 1
+      unhealthyNodeTimeout: 0s
+      workerRole: true
+      hostnamePrefix: elemental-cluster-fire-pool-
     machineSelectorConfig:
     - config:
         protect-kernel-defaults: false
     registries: {}
     upgradeStrategy:
-    controlPlaneConcurrency: '1'
-    controlPlaneDrainOptions:
+      controlPlaneConcurrency: '1'
+      controlPlaneDrainOptions:
         deleteEmptyDirData: true
         disableEviction: false
         enabled: false
@@ -62,8 +62,8 @@ rkeConfig:
         ignoreDaemonSets: true
         skipWaitForDeleteTimeoutSeconds: 0
         timeout: 120
-    workerConcurrency: '1'
-    workerDrainOptions:
+      workerConcurrency: '1'
+      workerDrainOptions:
         deleteEmptyDirData: true
         disableEviction: false
         enabled: false
@@ -72,56 +72,56 @@ rkeConfig:
         ignoreDaemonSets: true
         skipWaitForDeleteTimeoutSeconds: 0
         timeout: 120
-kubernetesVersion: v1.33.5+rke2r1
-localClusterAuthEndpoint:
+  kubernetesVersion: v1.33.5+rke2r1
+  localClusterAuthEndpoint:
     enabled: false
 ---
 apiVersion: elemental.cattle.io/v1beta1
 kind: MachineRegistration
 metadata:
-name: fire-nodes
-namespace: fleet-default
+  name: fire-nodes
+  namespace: fleet-default
 spec:
-config:
+  config:
     cloud-config:
-    users:
-    - name: root
+      users:
+      - name: root
         passwd: root
     elemental:
-    install:
+      install:
         device-selector:
         - key: Name
-        operator: In
-        values:
-        - /dev/sda
-        - /dev/vda
-        - /dev/nvme0
+          operator: In
+          values:
+          - /dev/sda
+          - /dev/vda
+          - /dev/nvme0
         - key: Size
-        operator: Gt
-        values:
-        - 25Gi
+          operator: Gt
+          values:
+          - 25Gi
         reboot: true
         snapshotter:
-        maxSnaps: 2
-        type: btrfs
-    reset:
+          maxSnaps: 2
+          type: btrfs
+      reset:
         reboot: true
         reset-oem: true
         reset-persistent: true
-machineInventoryLabels:
+  machineInventoryLabels:
     element: fire
 ---
 apiVersion: elemental.cattle.io/v1beta1
 kind: SeedImage
 metadata:
-name: fire-img
-namespace: fleet-default
+  name: fire-img
+  namespace: fleet-default
 spec:
-baseImage: registry.suse.com/suse/sl-micro/6.1/baremetal-iso-image:2.2.0-4.3
-cleanupAfterMinutes: 1440
-targetPlatform: linux/x86_64
-type: iso
-registrationRef:
+  baseImage: registry.suse.com/suse/sl-micro/6.1/baremetal-iso-image:2.2.0-4.3
+  cleanupAfterMinutes: 1440
+  targetPlatform: linux/x86_64
+  type: iso
+  registrationRef:
     apiVersion: elemental.cattle.io/v1beta1
     kind: MachineRegistration
     name: fire-nodes

--- a/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
+++ b/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
@@ -58,7 +58,7 @@
         namespace: fleet-default
         kubeconfig: "{{ kubeconfig_file }}"
         wait: yes
-        wait_timeout: 180
+        wait_timeout: 300
         validate_certs: false
         wait_condition:
           type: Ready

--- a/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
+++ b/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
@@ -25,6 +25,7 @@
         create_namespace: true
         wait: true
         wait_timeout: "60s"
+        chart_version: "1.9.1"
         validate_certs: false
       retries: 3
       delay: 60
@@ -38,6 +39,7 @@
         create_namespace: true
         wait: true
         wait_timeout: "60s"
+        chart_version: "1.9.1"
         validate_certs: false
       retries: 3
       delay: 60

--- a/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
+++ b/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
@@ -25,7 +25,6 @@
         create_namespace: true
         wait: true
         wait_timeout: "60s"
-        chart_version: "1.7.3"
         validate_certs: false
       retries: 3
       delay: 60
@@ -39,7 +38,6 @@
         create_namespace: true
         wait: true
         wait_timeout: "60s"
-        chart_version: "1.7.3"
         validate_certs: false
       retries: 3
       delay: 60

--- a/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
+++ b/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
@@ -5,6 +5,9 @@
   vars_files:
     - vars.yaml
 
+  vars:
+    elemental_chart_version: ""
+
   tasks:
     - name: Check if kubeconfig file exists
       stat:
@@ -25,6 +28,7 @@
         create_namespace: true
         wait: true
         wait_timeout: "60s"
+        chart_version: "{{ elemental_chart_version }}"
         validate_certs: false
       retries: 3
       delay: 60
@@ -38,6 +42,7 @@
         create_namespace: true
         wait: true
         wait_timeout: "60s"
+        chart_version: "{{ elemental_chart_version }}"
         validate_certs: false
       retries: 3
       delay: 60

--- a/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
+++ b/ansible/rancher/downstream/elemental/tasks/install-elemental-tasks.yml
@@ -25,7 +25,6 @@
         create_namespace: true
         wait: true
         wait_timeout: "60s"
-        chart_version: "1.9.1"
         validate_certs: false
       retries: 3
       delay: 60
@@ -39,7 +38,6 @@
         create_namespace: true
         wait: true
         wait_timeout: "60s"
-        chart_version: "1.9.1"
         validate_certs: false
       retries: 3
       delay: 60


### PR DESCRIPTION
This pull request updates the Ansible playbooks for deploying Elemental VMs using libvirt. The main changes ensure all required libvirt packages are installed and increase the wait timeout for Kubernetes resource readiness, improving reliability and compatibility.

**Libvirt package installation:**

* Added tasks to install `libvirt-daemon-system` and `libvirt-clients` packages to ensure all necessary libvirt components are present before VM creation.

**Kubernetes deployment reliability:**

* Increased the `wait_timeout` for waiting on Kubernetes resources from 180 to 300 seconds to allow more time for resources to become ready, reducing the chance of premature failures during deployment.