### PR TITLE
[UI] Add env flag to allow skip

### DIFF
--- a/ansible/testing/dashboard-e2e/QUICKSTART.md
+++ b/ansible/testing/dashboard-e2e/QUICKSTART.md
@@ -85,7 +85,7 @@ export AWS_SECRET_ACCESS_KEY="..."
 
 </details>
 
-See [`vars.yaml.example`](vars.yaml.example) for all available options.
+See [`vars.yaml.example`](vars.yaml.example) for all available options. Chart-related runs can use `allow_filtered_catalog_skip` (see the Cypress section in the [README](README.md#cypress-test-runner)).
 
 ---
 
@@ -120,6 +120,7 @@ tweak `cypress_tags` or dashboard code.
 | What changed | Command |
 | --- | --- |
 | Only `cypress_tags` in `vars.yaml` | `./run.sh stream test` |
+| `allow_filtered_catalog_skip` or other vars that affect `.env` | `./run.sh stream setup test` |
 | Dashboard source code | `./run.sh stream` |
 | Force-rebuild the runner image | `./run.sh build` then `./run.sh stream test` |
 

--- a/ansible/testing/dashboard-e2e/README.md
+++ b/ansible/testing/dashboard-e2e/README.md
@@ -300,6 +300,7 @@ rancher_image_tag: "head"
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `cypress_tags` | `@adminUser` | Cypress grep tags to run (e.g. `@userMenu`, `@adminUser+@components`) |
+| `allow_filtered_catalog_skip` | `true` | When `true`, chart tests may skip if the chart is filtered out of the UI catalog. Set to `false` to fail instead. |
 | `job_type` | `recurring` | `recurring` provisions new infra; `existing` skips provisioning |
 | `create_initial_clusters` | `true` | Whether to create import cluster and custom node. In `existing` mode, provisions only these resources (not the Rancher server) |
 | `dashboard_repo` | `rancher/dashboard` | Dashboard GitHub repo to clone |

--- a/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
+++ b/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
@@ -100,7 +100,9 @@ export default defineConfig({
     customNodeKey:       process.env.CUSTOM_NODE_KEY,
     accessibility:       !!process.env.TEST_A11Y, // Are we running accessibility tests?
     a11yFolder:          path.join('.', 'cypress', 'accessibility'),
-    gkeServiceAccount:   process.env.GKE_SERVICE_ACCOUNT
+    gkeServiceAccount:   process.env.GKE_SERVICE_ACCOUNT,
+    // Skip chart tests when the chart is filtered out of the UI catalog (default). Set to false to fail instead.
+    allowFilteredCatalogSkip: process.env.CYPRESS_ALLOW_FILTERED_CATALOG_SKIP !== 'false',
   },
   // Jenkins reporters configuration jUnit and HTML
   reporter:        'cypress-multi-reporters',

--- a/ansible/testing/dashboard-e2e/templates/env.j2
+++ b/ansible/testing/dashboard-e2e/templates/env.j2
@@ -31,5 +31,6 @@ QASE_DEBUG=true
 QASE_AUTOMATION_TOKEN={{ qase_token }}
 {% endif %}
 CYPRESS_grepTags={{ cypress_tags }}
+CYPRESS_ALLOW_FILTERED_CATALOG_SKIP={{ allow_filtered_catalog_skip | default(true) | bool | lower }}
 RANCHER_IMAGE_TAG={{ rancher_image_tag_resolved | default(rancher_image_tag) }}
 RANCHER_VERSION={{ rancher_version | default('') }}

--- a/ansible/testing/dashboard-e2e/vars.yaml.example
+++ b/ansible/testing/dashboard-e2e/vars.yaml.example
@@ -44,6 +44,7 @@ dashboard_branch: "master"
 
 # --- Cypress ---
 cypress_tags: "@adminUser"
+allow_filtered_catalog_skip: true  # When true (default), chart tests may skip if the chart is filtered out of the UI catalog. Set false to fail instead.
 job_type: "recurring"              # recurring | existing
 create_initial_clusters: true
 # rancher_host: ""                 # Required for job_type=existing


### PR DESCRIPTION
Adds CYPRESS_ALLOW_FILTERED_CATALOG_SKIP (default: allow skip when the chart is filtered from the catalog). Set it to false to fail the run instead of skipping in that case. 
Necessary to support https://github.com/rancher/dashboard/pull/17056