### PR TITLE
UI - Plumb CUSTOM_NODE_USER and persist tofu state for re-runs

### DIFF
--- a/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
+++ b/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
@@ -88,6 +88,22 @@
             name: _saved_rancher_vars
           when: _rancher_vars_file.stat.exists
 
+        - name: Set prefix from saved state
+          ansible.builtin.set_fact:
+            prefix: "{{ _saved_rancher_vars.prefix }}"
+          when:
+            - _rancher_vars_file.stat.exists
+            - "'prefix' in _saved_rancher_vars"
+            - (_saved_rancher_vars.prefix | default('')) | length > 0
+
+        - name: Set custom_node_ip from saved state
+          ansible.builtin.set_fact:
+            custom_node_ip: "{{ _saved_rancher_vars.custom_node_ip }}"
+          when:
+            - _rancher_vars_file.stat.exists
+            - "'custom_node_ip' in _saved_rancher_vars"
+            - (_saved_rancher_vars.custom_node_ip | default('')) | length > 0
+
         - name: Set rancher_host from saved state
           ansible.builtin.set_fact:
             rancher_host: "{{ _saved_rancher_vars.fqdn }}"

--- a/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
+++ b/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
@@ -98,6 +98,7 @@ export default defineConfig({
     azureClientSecret:   process.env.AZURE_CLIENT_SECRET,
     customNodeIp:        process.env.CUSTOM_NODE_IP,
     customNodeKey:       process.env.CUSTOM_NODE_KEY,
+    customNodeUser:      process.env.CUSTOM_NODE_USER || 'ec2-user',
     accessibility:       !!process.env.TEST_A11Y, // Are we running accessibility tests?
     a11yFolder:          path.join('.', 'cypress', 'accessibility'),
     gkeServiceAccount:   process.env.GKE_SERVICE_ACCOUNT,

--- a/ansible/testing/dashboard-e2e/tasks/install-k3s-rancher.yml
+++ b/ansible/testing/dashboard-e2e/tasks/install-k3s-rancher.yml
@@ -105,6 +105,8 @@
       cert_manager_version: '{{ cert_manager_version }}'
       kubeconfig_file: '{{ outputs_dir }}/kubeconfig-rancher.yaml'
       fqdn: '{{ rancher_host }}'
+      prefix: '{{ prefix }}'
+      custom_node_ip: '{{ custom_node_ip | default("") }}'
       bootstrap_password: '{{ bootstrap_password }}'
       password: '{{ rancher_password }}'
       rancher_chart_repo: '{{ rancher_helm_repo }}'

--- a/ansible/testing/dashboard-e2e/templates/env.j2
+++ b/ansible/testing/dashboard-e2e/templates/env.j2
@@ -19,6 +19,7 @@ GKE_SERVICE_ACCOUNT={{ gke_service_account }}
 {% endif %}
 CUSTOM_NODE_IP={{ custom_node_ip | default('') }}
 CUSTOM_NODE_KEY={{ custom_node_key | default('') }}
+CUSTOM_NODE_USER={{ aws_ssh_user | default('ec2-user') }}
 {% if percy_enabled | default(false) and percy_token | default('') | length > 0 and "@percy" in cypress_tags %}
 PERCY_TOKEN={{ percy_token }}
 {% endif %}


### PR DESCRIPTION
* `env.j2` + `cypress.config.jenkins.ts`: pipe a new CUSTOM_NODE_USER env var through to cypress, sourced from the existing aws_ssh_user. Lets the dashboard PO drive customnode SSH against an Ubuntu AMI (default still ec2-user) without root-login workarounds.

* `install-k3s-rancher.yml`: write `prefix` and `custom_node_ip` into outputs/rancher-vars.yaml at provision time.

* `dashboard-e2e-playbook.yml`: recover both alongside `rancher_host` in the existing pre_tasks block. Set them BEFORE rancher_host, otherwise the block's outer `when: rancher_host is not defined` short-circuits the remaining tasks.

Net effect: `./run.sh stream` (no provision) reuses existing infra instead of regenerating a random prefix and shipping an empty CUSTOM_NODE_IP into .env.

This is a dependency of: https://github.com/rancher/dashboard/pull/17465