### PR TITLE
Add shared directory and handle Kubernetes version incompatibility

### DIFF
--- a/ansible/k3s/shared/README.md
+++ b/ansible/k3s/shared/README.md
@@ -1,0 +1,94 @@
+# Shared K3s Playbooks
+
+This directory contains playbooks that are shared across all K3s deployment environments (default, airgap, proxy).
+
+## Structure
+
+```
+shared/
+├── bootstrap-python.yml              # Python 3.9+ bootstrap for minimal OS images
+└── playbooks/
+    ├── setup/
+    │   ├── setup-kubectl-access.yml   # Configure kubectl on bastion
+    │   └── setup-agent-nodes.yml     # Add agent nodes to cluster
+    ├── deploy/
+    │   └── rancher-helm-deploy-playbook.yml  # Deploy Rancher via Helm
+    └── debug/
+        └── validate-upgrade-readiness.yml    # Pre-upgrade validation
+```
+
+## Usage
+
+These playbooks are referenced by the main Makefile and should not be called directly in most cases.
+
+## Bootstrap Playbooks
+
+### bootstrap-python.yml
+Bootstraps Python 3.9+ on target nodes that don't have Python installed (e.g., SLE Micro).
+
+**Purpose**: Ansible requires Python to run, but minimal OS images may not have Python pre-installed. This playbook uses a static binary build to bootstrap Python before other playbooks can execute.
+
+**Method**: Downloads and installs pre-built Python binaries from indygreg/python-build-standalone.
+
+**When to use**: Automatically called by `make cluster` when Python is not detected on target nodes.
+
+## Setup Playbooks
+
+### setup/setup-kubectl-access.yml
+Configures kubectl on the bastion node with proper kubeconfig.
+
+**Purpose**: Enables cluster management from the bastion host.
+
+**Features**:
+- Downloads kubectl matching the K3s version
+- Fetches and configures kubeconfig from first cluster node
+- Tests cluster connectivity
+
+**Variables**:
+- `target`: Target group (default: 'master')
+
+**When to use**: Run `make kubectl-setup` after cluster deployment.
+
+### setup/setup-agent-nodes.yml
+Adds additional agent nodes to an existing K3s cluster.
+
+**Purpose**: Scale out clusters by adding worker nodes.
+
+**Features**:
+- Reads node token from local file
+- Installs K3s agent using k3s_install role
+- Waits for nodes to become ready
+- Supports parallel agent registration (serial: 3)
+
+**Variables**:
+- `target`: Target group (default: 'master')
+- `agent_group`: Group containing agent nodes (default: 'workers')
+
+**When to use**: Run `make agents` to add worker nodes.
+
+## Deploy Playbooks
+
+### deploy/rancher-helm-deploy-playbook.yml
+Deploys Rancher management server to K3s clusters using Helm.
+
+**Purpose**: Install Rancher for centralized cluster management.
+
+**Features**:
+- Helm-based deployment
+- Supports custom hostname configuration
+- Configurable for internal/external load balancers
+
+**Variables**:
+- `rancher_hostname`: Rancher server hostname
+- `internal_lb_hostname`: Internal load balancer hostname
+- `external_lb_hostname`: External load balancer hostname (optional)
+
+**When to use**: Run `make rancher` after cluster is ready.
+
+## Environment-Agnostic Design
+
+These playbooks work across all deployment environments by:
+- Using variable-based group naming (not hardcoded groups)
+- Avoiding environment-specific assumptions
+- Supporting both online and airgap deployments
+- Working with any K3s installation method

--- a/ansible/k3s/shared/bootstrap-python.yml
+++ b/ansible/k3s/shared/bootstrap-python.yml
@@ -1,0 +1,95 @@
+---
+# Bootstrap Python 3.9 on SLE Micro using pre-built binaries
+- name: Bootstrap Python 3.9 using pre-built binaries
+  hosts: all
+  become: true
+  gather_facts: false
+  vars:
+    python_url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20+20241016-x86_64-unknown-linux-gnu-install_only.tar.gz"
+    python_local_path: "/tmp/python39.tar.gz"
+    has_bastion: "{{ bastion_host is defined and bastion_user is defined }}"
+
+  tasks:
+    - name: Check if Python 3.9+ exists
+      ansible.builtin.raw: python3.9 --version 2>/dev/null || echo "NEEDS_INSTALL"
+      register: check_python
+      changed_when: false
+      failed_when: false
+
+    - name: Download Python binary on control machine (runs once)
+      ansible.builtin.get_url:
+        url: "{{ python_url }}"
+        dest: "{{ python_local_path }}"
+        mode: '0644'
+      become: false
+      run_once: true
+      delegate_to: localhost
+      register: download_python
+
+    - name: Copy Python binary from localhost to bastion (airgap)
+      ansible.builtin.shell: |
+        scp -i {{ ansible_ssh_private_key_file }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "{{ python_local_path }}" {{ bastion_user }}@{{ bastion_host }}:/tmp/python39.tar.gz
+      delegate_to: localhost
+      become: false
+      run_once: true
+      when: has_bastion
+
+    - name: Copy Python binary from bastion to target nodes (airgap)
+      ansible.builtin.shell: |
+        scp -i {{ ansible_ssh_private_key_file }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/python39.tar.gz {{ ansible_user }}@{{ ansible_host }}:/tmp/python39.tar.gz
+      delegate_to: bastion-node
+      become: false
+      when:
+        - has_bastion
+        - "'NEEDS_INSTALL' in check_python.stdout"
+
+    - name: Copy Python binary directly to target nodes (default)
+      ansible.builtin.shell: |
+        scp -i {{ ansible_ssh_private_key_file }} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "{{ python_local_path }}" {{ ansible_user }}@{{ ansible_host }}:/tmp/python39.tar.gz
+      delegate_to: localhost
+      become: false
+      when:
+        - not has_bastion
+        - "'NEEDS_INSTALL' in check_python.stdout"
+
+    - name: Install Python from local copy
+      ansible.builtin.raw: |
+        set -e
+        tmp_dir=$(mktemp -d)
+        cd "$tmp_dir"
+
+        echo "Installing Python from local copy..."
+        tar xzf /tmp/python39.tar.gz -C /usr/local --strip-components=1
+
+        # Verify
+        /usr/local/bin/python3 --version
+
+        # Create symlinks (ignore errors if they exist)
+        ln -sf /usr/local/bin/python3 /usr/local/bin/python3.9 2>/dev/null || true
+        ln -sf /usr/local/bin/pip3 /usr/local/bin/pip3.9 2>/dev/null || true
+
+        # Cleanup
+        cd /
+        rm -rf "$tmp_dir"
+        rm -f /tmp/python39.tar.gz
+
+        echo "Python 3.9 installed successfully via binary"
+      register: install_binary
+      when: "'NEEDS_INSTALL' in check_python.stdout"
+
+    - name: Verify installation
+      ansible.builtin.raw: /usr/local/bin/python3.9 --version || /usr/local/bin/python3 --version || echo "Failed"
+      register: verify
+      changed_when: false
+
+    - name: Show version
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }}: {{ verify.stdout | default('Verification failed') }}"
+
+    - name: Cleanup local copy on control machine
+      ansible.builtin.file:
+        path: "{{ python_local_path }}"
+        state: absent
+      become: false
+      run_once: true
+      delegate_to: localhost

--- a/ansible/k3s/shared/playbooks/deploy/rancher-helm-deploy-playbook.yml
+++ b/ansible/k3s/shared/playbooks/deploy/rancher-helm-deploy-playbook.yml
@@ -1,0 +1,264 @@
+---
+- name: Deploy Rancher to K3s Cluster using Helm
+  hosts: bastion
+  gather_facts: true
+
+  vars:
+    rancher_private_hostname: "{{ internal_lb_hostname }}"
+    rancher_public_hostname: "{{ external_lb_hostname | default(rancher_hostname) }}"
+    kubeconfig_path: "/home/{{ ansible_user }}/.kube/config"
+    repo_root: "{{ playbook_dir | dirname | dirname | dirname | dirname | dirname }}"
+
+  pre_tasks:
+    - name: Check if kubectl is available
+      ansible.builtin.stat:
+        path: "{{ kubeconfig_path }}"
+      register: kubectl_config
+
+    - name: Fail if kubectl is not configured
+      ansible.builtin.fail:
+        msg: |
+          kubectl is not configured on the bastion node.
+          Please run the kubectl setup playbook first:
+          ansible-playbook -i inventory/inventory.yml shared/playbooks/setup/setup-kubectl-access.yml
+      when: not kubectl_config.stat.exists
+
+    - name: Test kubectl connectivity to K3s cluster
+      ansible.builtin.command: kubectl get nodes
+      register: kubectl_nodes
+      until: kubectl_nodes.rc == 0
+      retries: 6
+      delay: 10
+      changed_when: false
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
+
+    - name: Display cluster nodes
+      ansible.builtin.debug:
+        msg: "K3s cluster nodes: {{ kubectl_nodes.stdout_lines }}"
+
+    - name: Check if python3-pip is already installed
+      ansible.builtin.command: python3 -m pip --version
+      register: pip_check
+      changed_when: false
+      failed_when: false
+
+    - name: Install pip3 if not present
+      ansible.builtin.package:
+        name: python3-pip
+        state: present
+        update_cache: true
+      when: pip_check.rc != 0
+      become: true
+      ignore_errors: true
+
+    - name: Display pip installation status
+      ansible.builtin.debug:
+        msg: "Python3-pip installation: {{ 'Already installed' if pip_check.rc == 0 else 'Installation attempted (may have failed in airgap environment)' }}"
+
+    - name: Install Ansible and required packages
+      ansible.builtin.package:
+        name:
+          - ansible
+          - python3-kubernetes
+          - python3-yaml
+        state: present
+        update_cache: true
+      become: true
+      ignore_errors: true
+
+    - name: Install Ansible Kubernetes collection if not present
+      ansible.builtin.command: ansible-galaxy collection install kubernetes.core
+      register: collection_install
+      failed_when: collection_install.rc != 0 and 'already satisfied' not in collection_install.stderr
+      changed_when: collection_install.rc == 0 and 'already satisfied' not in collection_install.stderr
+
+  roles:
+    - role: airgap_rancher_helm_deploy
+      tags:
+        - rancher
+
+  post_tasks:
+    - name: Wait for Rancher pods to be ready
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ rancher_namespace }}"
+        label_selectors:
+          - app=rancher
+        kubeconfig: "{{ kubeconfig_path }}"
+        wait_condition:
+          type: Ready
+          status: "True"
+        wait_timeout: 600
+
+    - name: Get Rancher pod status
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ rancher_namespace }}"
+        label_selectors:
+          - app=rancher
+        kubeconfig: "{{ kubeconfig_path }}"
+      register: rancher_pods
+
+    - name: Display Rancher pod information
+      ansible.builtin.debug:
+        msg: |
+          Rancher Pods Status:
+          {% for pod in rancher_pods.resources %}
+          - {{ pod.metadata.name }}: {{ pod.status.phase }}
+          {% endfor %}
+
+    - name: Add internal hostname to ingress
+      when: (rancher_private_hostname is defined or internal_lb_hostname is defined) and (rancher_public_hostname is defined or external_lb_hostname is defined)
+      block:
+        - name: Set fact for new Ingress Rule
+          ansible.builtin.set_fact:
+            ingress_rules:
+              - host: "{{ rancher_private_hostname }}"
+                http:
+                  paths:
+                    - backend:
+                        service:
+                          name: "rancher"
+                          port:
+                            number: 80
+                      path: /
+                      pathType: ImplementationSpecific
+              - host: "{{ rancher_public_hostname }}"
+                http:
+                  paths:
+                    - backend:
+                        service:
+                          name: "rancher"
+                          port:
+                            number: 80
+                      path: /
+                      pathType: ImplementationSpecific
+
+        - name: Patch the Ingress to add the new hostname rule and TLS host
+          kubernetes.core.k8s:
+            state: patched
+            api_version: networking.k8s.io/v1
+            kind: Ingress
+            name: "rancher"
+            namespace: "cattle-system"
+            definition:
+              spec:
+                rules: "{{ ingress_rules }}"
+                tls:
+                  - hosts:
+                      - "{{ rancher_private_hostname }}"
+                      - "{{ rancher_public_hostname }}"
+                    secretName: tls-rancher-ingress
+
+    - name: Get LoadBalancer or NodePort service details
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Service
+        name: rancher
+        namespace: "{{ rancher_namespace }}"
+        kubeconfig: "{{ kubeconfig_path }}"
+      register: rancher_service_info
+
+    - name: Final deployment verification
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        name: rancher
+        namespace: "{{ rancher_namespace }}"
+        kubeconfig: "{{ kubeconfig_path }}"
+      register: rancher_deployment_status
+
+    - name: Verify deployment is ready
+      ansible.builtin.assert:
+        that:
+          - rancher_deployment_status.resources[0].status.readyReplicas | default(0) > 0
+        fail_msg: "Rancher deployment is not ready"
+        success_msg: "Rancher deployment is ready and functional"
+
+    # --- Admin setup ---
+
+    - name: Ensure tmp directory exists
+      ansible.builtin.file:
+        path: "{{ repo_root }}/tmp"
+        state: directory
+        mode: "0700"
+      delegate_to: localhost
+
+    - name: Configure Rancher admin user and generate API token
+      ansible.builtin.include_role:
+        name: rancher_auth
+      vars:
+        rancher_url: "https://{{ rancher_private_hostname }}"
+        rancher_token_password: "{{ rancher_bootstrap_password }}"
+        rancher_permanent_password: "{{ rancher_admin_password }}"
+        rancher_token_output_file: "{{ repo_root }}/tmp/rancher-admin-token.json"
+        rancher_token_output_format: "json"
+
+    - name: Set Rancher server URL
+      ansible.builtin.uri:
+        url: "https://{{ rancher_private_hostname }}/v3/settings/server-url"
+        method: PUT
+        headers:
+          Accept: "application/json"
+          Content-Type: "application/json"
+          Authorization: "Bearer {{ rancher_generated_token }}"
+        body:
+          name: "server-url"
+          value: "https://{{ rancher_private_hostname }}"
+        body_format: json
+        validate_certs: false
+        status_code: 200
+      retries: 5
+      delay: 10
+
+    - name: Create Rancher configuration summary
+      ansible.builtin.copy:
+        content: |
+          # Rancher Deployment Summary
+          Deployment Date: {{ ansible_date_time.iso8601 }}
+          Rancher Version: {{ rancher_chart_version | default('latest') }}
+          Hostname: {{ rancher_private_hostname }}
+          Public Hostname: {{ rancher_public_hostname }}
+          Namespace: {{ rancher_namespace }}
+          TLS Source: {{ rancher_tls_source }}
+
+          Admin Credentials:
+          - Username: admin
+          - Password: {{ rancher_admin_password }}
+          - API Token: {{ rancher_generated_token }}
+
+          Access Instructions:
+          1. Configure DNS or add to /etc/hosts: {{ rancher_public_hostname }} -> <LoadBalancer-IP or Node-IP>
+          2. Navigate to: https://{{ rancher_public_hostname }}
+          3. Login with admin / {{ rancher_admin_password }}
+
+          Troubleshooting:
+          - Check pods: kubectl get pods -n {{ rancher_namespace }}
+          - Check services: kubectl get svc -n {{ rancher_namespace }}
+          - Check ingress: kubectl get ingress -n {{ rancher_namespace }}
+          - View logs: kubectl logs -n {{ rancher_namespace }} -l app=rancher
+        dest: "/home/{{ ansible_user }}/rancher-deployment-summary.txt"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "0600"
+
+    - name: Display Rancher access information
+      ansible.builtin.debug:
+        msg:
+          - "RANCHER DEPLOYMENT COMPLETE"
+          - ""
+          - "  Access URL:     https://{{ rancher_public_hostname }}"
+          - "  Internal URL:   https://{{ rancher_private_hostname }}"
+          - "  Namespace:      {{ rancher_namespace }}"
+          - ""
+          - "  Admin Username: admin"
+          - "  Admin Password: {{ rancher_admin_password }}"
+          - "  API Token:      {{ rancher_generated_token }}"
+          - ""
+          - "  Service Type:   {{ rancher_service_info.resources[0].spec.type }}"
+          - ""
+          - "  Token file:     {{ repo_root }}/tmp/rancher-admin-token.json"
+          - "  Summary file:   /home/{{ ansible_user }}/rancher-deployment-summary.txt"

--- a/ansible/k3s/shared/playbooks/deploy/rancher-helm-deploy-playbook.yml
+++ b/ansible/k3s/shared/playbooks/deploy/rancher-helm-deploy-playbook.yml
@@ -228,7 +228,7 @@
           Admin Credentials:
           - Username: admin
           - Password: {{ rancher_admin_password }}
-          - API Token: {{ rancher_generated_token }}
+          - API Token: See {{ repo_root }}/tmp/rancher-admin-token.json
 
           Access Instructions:
           1. Configure DNS or add to /etc/hosts: {{ rancher_public_hostname }} -> <LoadBalancer-IP or Node-IP>
@@ -255,8 +255,8 @@
           - "  Namespace:      {{ rancher_namespace }}"
           - ""
           - "  Admin Username: admin"
-          - "  Admin Password: {{ rancher_admin_password }}"
-          - "  API Token:      {{ rancher_generated_token }}"
+          - "  Admin Password: <see summary file>"
+          - "  API Token:      <see token file>"
           - ""
           - "  Service Type:   {{ rancher_service_info.resources[0].spec.type }}"
           - ""

--- a/ansible/k3s/shared/playbooks/setup/setup-agent-nodes.yml
+++ b/ansible/k3s/shared/playbooks/setup/setup-agent-nodes.yml
@@ -1,0 +1,75 @@
+---
+- name: Setup K3s Agent Nodes
+  hosts: "{{ agent_group | default('workers') }}"
+  become: true
+  gather_facts: true
+  serial: 3 # Process 3 agents at a time instead of 1
+  vars:
+    target_group: "{{ target | default('master') }}"
+    node_token_file: "/tmp/node_token.txt"
+  tasks:
+    - name: Read node_token from local file
+      ansible.builtin.slurp:
+        src: "{{ node_token_file }}"
+      delegate_to: localhost
+      run_once: true
+      become: false
+      register: node_token_file_content
+
+    - name: Set node_token fact from file content
+      ansible.builtin.set_fact:
+        node_token: "{{ node_token_file_content.content | b64decode | trim }}"
+      run_once: true
+      delegate_to: localhost
+
+    - name: Stop any existing K3s services
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: stopped
+      failed_when: false
+      loop:
+        - k3s
+        - k3s-agent
+
+    - name: Create K3s agent directory
+      ansible.builtin.file:
+        path: /etc/rancher/k3s
+        state: directory
+        mode: "0755"
+
+    - name: Install K3s on agent nodes
+      ansible.builtin.include_role:
+        name: k3s_install
+      vars:
+        k3s_node_type: agent
+        k3s_api_host: "{{ kube_api_host }}"
+        k3s_fqdn: "{{ fqdn | default(kube_api_host) }}"
+        k3s_token: "{{ node_token }}"
+        public_ip: "{{ ansible_host }}"
+        k3s_worker_flags: "{{ worker_flags | default('') }}"
+        k3s_channel: "{{ channel | default('latest') }}"
+
+    - name: Wait for agent to join cluster
+      ansible.builtin.shell: |
+        export KUBECONFIG={{ kubeconfig_file | default('/etc/rancher/k3s/k3s.yaml') }}
+        kubectl get node {{ inventory_hostname }} --no-headers 2>/dev/null | grep -q " Ready"
+      delegate_to: "{{ groups[target_group][0] }}"
+      become: true
+      register: agent_join_check
+      until: agent_join_check.rc == 0
+      retries: 12
+      delay: 10
+      changed_when: false
+
+    - name: Check K3s service status
+      ansible.builtin.systemd:
+        name: k3s-agent
+      register: k3s_status
+
+    - name: Display service status
+      ansible.builtin.debug:
+        msg: |
+          {{ inventory_hostname }} K3s Agent Service Status:
+          Name: {{ k3s_status.name }}
+          State: {{ k3s_status.status.ActiveState }}
+          Enabled: {{ k3s_status.status.UnitFileState }}

--- a/ansible/k3s/shared/playbooks/setup/setup-kubectl-access.yml
+++ b/ansible/k3s/shared/playbooks/setup/setup-kubectl-access.yml
@@ -1,0 +1,147 @@
+---
+- name: Setup kubectl access on bastion node
+  hosts: bastion
+  become: true
+  gather_facts: true
+  vars:
+    target_group: "{{ target | default('master') }}"
+    kubeconfig_local_file: "{{ kubeconfig_file | default('/tmp/k3s-kubeconfig.yaml') }}"
+  tasks:
+    - name: Extract Kubernetes version from K3s version
+      ansible.builtin.set_fact:
+        k8s_version: "{{ kubernetes_version | regex_replace('^v([0-9]+\\.[0-9]+\\.[0-9]+).*', 'v\\1') }}"
+
+    - name: Display Kubernetes version for kubectl
+      ansible.builtin.debug:
+        msg: "Installing kubectl version {{ k8s_version }} to match K3s {{ kubernetes_version }}"
+
+    - name: Download kubectl binary with SHA256 verification
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/../../../../tasks/download-kubectl.yml"
+      vars:
+        kubectl_version: "{{ k8s_version }}"
+
+    - name: Verify kubectl installation
+      ansible.builtin.command: kubectl version --client
+      register: kubectl_version_output
+      changed_when: false
+
+    - name: Display kubectl version
+      ansible.builtin.debug:
+        msg: "kubectl installed: {{ kubectl_version_output.stdout }}"
+
+    - name: Create .kube directory for root
+      ansible.builtin.file:
+        path: /root/.kube
+        state: directory
+        mode: "0700"
+        owner: root
+        group: root
+
+    - name: Create .kube directory for ansible user
+      ansible.builtin.file:
+        path: "/home/{{ ansible_user }}/.kube"
+        state: directory
+        mode: "0700"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+      when: ansible_user is defined and ansible_user != 'root'
+
+    - name: Fetch KUBECONFIG from first cluster node
+      ansible.builtin.fetch:
+        src: /etc/rancher/k3s/k3s.yaml
+        dest: "/tmp/k3s-{{ inventory_hostname }}.yaml"
+        flat: true
+      delegate_to: "{{ groups[target_group][0] }}"
+      become: true
+
+    - name: Read kubeconfig content
+      ansible.builtin.slurp:
+        src: "/tmp/k3s-{{ inventory_hostname }}.yaml"
+      register: kubeconfig_content
+      delegate_to: localhost
+      become: false
+
+    - name: Update server URL in kubeconfig content
+      ansible.builtin.set_fact:
+        updated_kubeconfig: >-
+          {{ (kubeconfig_content.content | b64decode) |
+          regex_replace('https://127\.0\.0\.1:6443',
+          'https://' + hostvars[groups[target_group][0]]['ansible_host'] + ':6443') }}
+
+    - name: Write kubeconfig to bastion root
+      ansible.builtin.copy:
+        content: "{{ updated_kubeconfig }}"
+        dest: /root/.kube/config
+        mode: "0600"
+        owner: root
+        group: root
+
+    - name: Write kubeconfig to ansible user
+      ansible.builtin.copy:
+        content: "{{ updated_kubeconfig }}"
+        dest: "/home/{{ ansible_user }}/.kube/config"
+        mode: "0600"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+      when: ansible_user is defined and ansible_user != 'root'
+
+    - name: Clean up temporary kubeconfig
+      ansible.builtin.file:
+        path: "/tmp/k3s-{{ inventory_hostname }}.yaml"
+        state: absent
+      delegate_to: localhost
+      become: false
+
+    - name: Test kubectl connectivity
+      ansible.builtin.command: kubectl get nodes -o wide
+      environment:
+        KUBECONFIG: /root/.kube/config
+      register: kubectl_test
+      failed_when: false
+      changed_when: false
+
+    - name: Display kubectl test results
+      ansible.builtin.debug:
+        msg: |
+          kubectl connectivity test:
+          {% if kubectl_test.rc == 0 %}
+          SUCCESS - Cluster accessible from bastion:
+          {{ kubectl_test.stdout }}
+          {% else %}
+          FAILED - Error connecting to cluster:
+          {{ kubectl_test.stderr }}
+
+          Troubleshooting steps:
+          1. Verify K3s is running on cluster nodes
+          2. Check network connectivity from bastion to cluster nodes
+          3. Verify kubeconfig server URL is correct
+          {% endif %}
+
+    - name: Display final instructions
+      ansible.builtin.debug:
+        msg: |
+          kubectl Access Setup Complete!
+
+          [OK] kubectl installed on bastion node
+          [OK] KUBECONFIG copied and configured
+
+          To manage your cluster from the bastion node:
+
+          As root:
+          kubectl get nodes
+          kubectl get pods -A
+          kubectl get services -A
+
+          As {{ ansible_user | default('your user') }}:
+          kubectl get nodes
+          kubectl get pods -A
+          kubectl get services -A
+
+          The kubeconfig is located at:
+          - /root/.kube/config
+          {% if ansible_user is defined and ansible_user != 'root' %}
+          - /home/{{ ansible_user }}/.kube/config
+          {% endif %}
+
+          You can also use kubectl with explicit kubeconfig:
+          kubectl --kubeconfig=/root/.kube/config get nodes

--- a/ansible/rancher/default-ha/rancher-playbook.yml
+++ b/ansible/rancher/default-ha/rancher-playbook.yml
@@ -447,6 +447,7 @@
         content: |
           fqdn = "https://{{ fqdn }}"
           api_key = "{{ rancher_generated_token }}"
+        mode: "0600"
 
     - name: Display Rancher deployment summary
       ansible.builtin.debug:
@@ -455,9 +456,6 @@
           - "  RANCHER DEPLOYMENT COMPLETE"
           - "============================================================"
           - "  URL:        https://{{ fqdn }}"
-          - "  Username:   admin"
-          - "  Password:   {{ password }}"
-          - "  API Token:  {{ rancher_generated_token }}"
           - ""
           - "  Token file: {{ playbook_dir }}/generated.tfvars"
           - "  K8s version: {{ k8s_cluster_version }}"

--- a/ansible/rancher/default-ha/rancher-playbook.yml
+++ b/ansible/rancher/default-ha/rancher-playbook.yml
@@ -47,20 +47,20 @@
     - name: Set variables based on tofu or environment
       when: fqdn is not defined
       block:
-      - name: Check if using tfstate file
-        ansible.builtin.stat:
-          path: "{{ terraform_state_file }}"
-        register: tfstate_file_stat
+        - name: Check if using tfstate file
+          ansible.builtin.stat:
+            path: "{{ terraform_state_file }}"
+          register: tfstate_file_stat
 
-      - name: Set fqdn content from tfstate file if it exists
-        ansible.builtin.set_fact:
-          fqdn: "{{ lookup('cloud.terraform.tf_output', 'fqdn', state_file=terraform_state_file) }}"
-        when: tfstate_file_stat.stat.exists
+        - name: Set fqdn content from tfstate file if it exists
+          ansible.builtin.set_fact:
+            fqdn: "{{ lookup('cloud.terraform.tf_output', 'fqdn', state_file=terraform_state_file) }}"
+          when: tfstate_file_stat.stat.exists
 
-      - name: Set fqdn content from env when not using terraform
-        ansible.builtin.set_fact:
-          fqdn: "{{ lookup('env', 'FQDN') }}"
-        when: not tfstate_file_stat.stat.exists
+        - name: Set fqdn content from env when not using terraform
+          ansible.builtin.set_fact:
+            fqdn: "{{ lookup('env', 'FQDN') }}"
+          when: not tfstate_file_stat.stat.exists
 
     - name: Check if kubeconfig file exists
       stat:
@@ -100,9 +100,20 @@
       retries: 5
       delay: 15
 
+    - name: Get Kubernetes cluster version
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig_file }}"
+        api_version: v1
+        kind: Node
+      register: cluster_nodes_info
+
+    - name: Extract Kubernetes server version
+      ansible.builtin.set_fact:
+        k8s_cluster_version: "{{ cluster_nodes_info.resources[0].status.nodeInfo.kubeletVersion }}"
+
     - name: Show connection result
       debug:
-        msg: "Connected! Found {{ ns_info.resources | length }} namespaces."
+        msg: "Connected! Found {{ ns_info.resources | length }} namespaces. Kubernetes version: {{ k8s_cluster_version }}"
 
     - name: Download cert-manager CRDs with SHA256 verification
       include_role:
@@ -231,6 +242,64 @@
         rancher_chart_version: "{{ rancher_version | regex_replace('^v', '') if rancher_version != 'latest' else '' }}"
       when: rancher_version != ""
 
+    - name: Get Rancher chart metadata
+      ansible.builtin.command:
+        cmd: >-
+          helm show chart {{ rancher_chart_repo_final }}/rancher
+          {{ ('--version ' + rancher_chart_version) if rancher_chart_version else '' }}
+      register: rancher_chart_metadata
+      changed_when: false
+
+    - name: Extract Rancher chart kubeVersion
+      ansible.builtin.set_fact:
+        rancher_chart_kube_version: "{{ (rancher_chart_metadata.stdout | regex_search('kubeVersion:\\s*(.+)', '\\1') | first).strip() }}"
+      when:
+        - rancher_chart_metadata.stdout is defined
+        - rancher_chart_metadata.stdout | regex_search('kubeVersion:') is not none
+
+    - name: Display version compatibility info
+      ansible.builtin.debug:
+        msg: >-
+          Cluster Kubernetes version: {{ k8s_cluster_version }}
+          - Rancher chart kubeVersion: {{ rancher_chart_kube_version | default('not specified') }}
+
+    - name: Dry-run Rancher install to verify Kubernetes version compatibility
+      ansible.builtin.command:
+        cmd: >-
+          helm install rancher {{ rancher_chart_repo_final }}/rancher
+          --dry-run
+          --namespace cattle-system
+          {{ ('--version ' + rancher_chart_version) if rancher_chart_version else '' }}
+          --set hostname={{ fqdn }}
+          --set bootstrapPassword={{ bootstrap_password }}
+          --kubeconfig {{ kubeconfig_file }}
+      register: rancher_dry_run
+      changed_when: false
+      # Don't fail yet if the error is about kubeVersion incompatibility;
+      # we handle that with a clear message in the next task.
+      failed_when:
+        - rancher_dry_run.rc != 0
+        - rancher_dry_run.stderr is not defined or 'incompatible' not in rancher_dry_run.stderr
+
+    - name: Fail on Kubernetes version incompatibility
+      ansible.builtin.fail:
+        msg: |-
+          INCOMPATIBLE KUBERNETES VERSION
+          ================================
+          Cluster version: {{ k8s_cluster_version }}
+          Rancher chart requires: {{ rancher_chart_kube_version | default('see below') }}
+
+          {{ rancher_dry_run.stderr }}
+
+          The Rancher chart does not support Kubernetes {{ k8s_cluster_version }}.
+          Options:
+            1. Downgrade Kubernetes to a version matching {{ rancher_chart_kube_version | default('see below') }}
+            2. Use a newer Rancher chart version that supports Kubernetes {{ k8s_cluster_version }}
+            3. Check the Rancher support matrix: https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/
+      when:
+        - rancher_dry_run.rc != 0
+        - rancher_dry_run.stderr is defined and 'incompatible' in rancher_dry_run.stderr
+
     - name: Build base Rancher helm values
       set_fact:
         rancher_helm_values:
@@ -343,11 +412,6 @@
       delay: 10
       until: webpage_result.status == 200
 
-    - name: Display Rancher URL
-      debug:
-        msg: "Rancher URL: https://{{ rancher_ingress.resources[0].spec.rules[0].host }}"
-      when: rancher_version != "" and rancher_ingress.resources|length > 0 and rancher_ingress.resources[0].spec.rules|length > 0 and rancher_ingress.resources[0].spec.rules[0].host is defined
-
     - name: Configure Rancher admin user and generate API token
       ansible.builtin.include_role:
         name: rancher_auth
@@ -377,17 +441,28 @@
       delay: 10
       when: rancher_version != ""
 
-    - name: Print API token
-      ansible.builtin.debug:
-        msg: "RANCHER_API_KEY: {{ rancher_generated_token }}"
-      when: rancher_version != ""
-
     - name: Write multiple variables to file
       copy:
         dest: generated.tfvars
         content: |
           fqdn = "https://{{ fqdn }}"
           api_key = "{{ rancher_generated_token }}"
+
+    - name: Display Rancher deployment summary
+      ansible.builtin.debug:
+        msg:
+          - "============================================================"
+          - "  RANCHER DEPLOYMENT COMPLETE"
+          - "============================================================"
+          - "  URL:        https://{{ fqdn }}"
+          - "  Username:   admin"
+          - "  Password:   {{ password }}"
+          - "  API Token:  {{ rancher_generated_token }}"
+          - ""
+          - "  Token file: {{ playbook_dir }}/generated.tfvars"
+          - "  K8s version: {{ k8s_cluster_version }}"
+          - "============================================================"
+      when: rancher_version != ""
 
     - name: Upgrade Rancher
       ansible.builtin.include_tasks: rancher-upgrade-tasks.yml


### PR DESCRIPTION
This pull request introduces a set of shared Ansible playbooks for K3s cluster management, aimed at standardizing cluster operations across different environments (default, airgap, proxy). The main additions are comprehensive, environment-agnostic playbooks for Python bootstrapping, kubectl setup, agent node scaling, and Rancher deployment via Helm. Each playbook is well-documented and modular, improving maintainability and reusability.

The most important changes are:

**Documentation and Structure**
- Added `ansible/k3s/shared/README.md` to provide a clear overview of the shared playbooks, their structure, purposes, and usage instructions. This documentation clarifies the environment-agnostic design and outlines when and how each playbook should be used.

**Bootstrap and Setup Playbooks**
- Introduced `bootstrap-python.yml` for bootstrapping Python 3.9+ on minimal OS images (e.g., SLE Micro), with support for both online and airgap environments. The playbook handles downloading, transferring, and installing a pre-built Python binary, ensuring Ansible compatibility on all nodes.
- Added `setup/setup-kubectl-access.yml` to automate kubectl installation on the bastion node, fetch and configure kubeconfig from the cluster, and verify connectivity, making cluster management from the bastion node straightforward.
- Added `setup/setup-agent-nodes.yml` to automate the process of adding agent nodes to a K3s cluster, including reading the node token, installing K3s, and verifying node readiness in parallel.

**Deployment Playbooks**
- Added `deploy/rancher-helm-deploy-playbook.yml` to automate Rancher deployment on K3s clusters using Helm. The playbook includes pre-flight checks, dependency installation, Rancher deployment, ingress configuration, admin user setup, and post-deployment verification and summary.

These additions provide a robust, reusable foundation for K3s cluster lifecycle management across multiple environments.