### PR TITLE
match ingress-controller value 'ingress-nginx' instead of 'nginx'

### DIFF
--- a/ansible/rke2/default/rke2-playbook.yml
+++ b/ansible/rke2/default/rke2-playbook.yml
@@ -322,7 +322,7 @@
       
     - name: Detect ingress controller type
       ansible.builtin.set_fact:
-        ingress_controller: "{{ 'nginx' if (server_flags | default('')) is search('ingress-controller:\\s*nginx') else 'traefik' }}"
+        ingress_controller: "{{ 'nginx' if (server_flags | default('')) is search('ingress-controller:\\s*ingress-nginx') else 'traefik' }}"
 
     - name: Wait for ingress-nginx admission webhook to be ready
       kubernetes.core.k8s_info:


### PR DESCRIPTION
The regex looked for ingress-controller: nginx, but RKE2 only accepts ingress-nginx. Updated the regex so the valid value is detected correctly and the playbook doesn't fall through to waiting on traefik.