### PR TITLE
Add curl to dashboard-e2e runner and honor dashboard_branch override

### DIFF
--- a/ansible/testing/dashboard-e2e/files/Dockerfile.ci
+++ b/ansible/testing/dashboard-e2e/files/Dockerfile.ci
@@ -10,6 +10,12 @@ RUN wget -q "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubect
     echo "${KUBECTL_SUM}  /tmp/kubectl" | sha256sum -c - && \
     mv /tmp/kubectl /bin/kubectl && \
     chmod +x /bin/kubectl
+
+# curl is required by the imported-cluster registration command
+# (`curl --insecure -sfL <manifest> | kubectl apply -f -`) executed by
+# cypress/e2e/tests/pages/manager/cluster-manager.spec.ts.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /root/.kube
 
 COPY imported_config /root/.kube/config

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -16,7 +16,9 @@
 - name: Detect dashboard target branch
   ansible.builtin.set_fact:
     target_branch: >-
-      {%- if rancher_image_tag == 'head' -%}
+      {%- if dashboard_branch is defined and dashboard_branch and dashboard_branch != 'master' -%}
+        {{ dashboard_branch }}
+      {%- elif rancher_image_tag == 'head' -%}
         master
       {%- elif rancher_image_tag is match('^v(\d+\.\d+)') -%}
         release-{{ rancher_image_tag | regex_replace('^v(\d+\.\d+).*$', '\1') }}


### PR DESCRIPTION
## Changes

- **`files/Dockerfile.ci`**: install `curl` in the Cypress runner image. The imported cluster e2e (`cluster-manager.spec.ts`) shells out to `curl --insecure -sfL <manifest> | kubectl apply -f -` to register the imported cluster; the cypress/factory base does not include curl.

- **`tasks/setup-test-env.yml`**: when `dashboard_branch` is explicitly set to a non-master value, use it as the target branch regardless of `rancher_image_tag`. Previously `rancher_image_tag` (e.g. `head`) would force `master` even when a contributor passed a fix branch.

All current Jenkins jobs in `rancherlabs/jenkins-job-builder/ui-qa-tests-ansible.yml` set `dashboard_branch: master`, so existing behaviour is preserved. The overlay logic that pulls master deps onto a release branch (Yonas's release-2.14 scenario) is unaffected.

## Why

Enables running individual fix branches against any Rancher image (head, v2.x) without having to alias `master` locally, and unblocks the imported cluster spec on the Cypress runner.

Related: rancher/qa-tasks#2317