### PR TITLE
Fix latent issues in setup role and rancher_user_setup

### DIFF
--- a/ansible/roles/rancher_user_setup/tasks/_create_user.yml
+++ b/ansible/roles/rancher_user_setup/tasks/_create_user.yml
@@ -51,6 +51,10 @@
       Authorization: "Bearer {{ _rancher_admin_token }}"
     validate_certs: "{{ rancher_validate_certs }}"
     status_code: [200, 201, 409, 422]
+  register: _bind_global_result
+  retries: 5
+  delay: 15
+  until: _bind_global_result.status | default(0) in [200, 201, 409, 422]
   loop: "{{ _user.global_roles | default([]) }}"
   loop_control:
     loop_var: _role

--- a/ansible/roles/setup/tasks/main.yml
+++ b/ansible/roles/setup/tasks/main.yml
@@ -25,9 +25,9 @@
 
 - name: Set OS facts
   set_fact:
-    _os_id:   "{{ (osr.stdout | default('||')).split('|')[0] | lower }}"
-    _os_like: "{{ (osr.stdout | default('||')).split('|')[1] | lower }}"
-    _os_ver:  "{{ (osr.stdout | default('||')).split('|')[2] }}"
+    _os_id:   "{{ (osr.stdout | default('||') | trim).split('|')[0] | lower }}"
+    _os_like: "{{ (osr.stdout | default('||') | trim).split('|')[1] | lower }}"
+    _os_ver:  "{{ (osr.stdout | default('||') | trim).split('|')[2] }}"
 
 - name: Debian/Ubuntu | Ensure Python3 (>=3.8) is installed
   raw: >
@@ -37,7 +37,7 @@
     apt-get install -y python3"
   when: 
     - (_os_id in ['debian','ubuntu'])
-    - (pyver.stdout is version('3.8', '<'))
+    - (pyver.stdout | trim is version('3.8', '<'))
 
 - name: RHEL-family | ensure python39 (or python3)
   raw: |
@@ -50,7 +50,7 @@
     fi
   when: 
     - (_os_id in ['rhel','centos','rocky','almalinux','ol'] or 'rhel' in _os_like)
-    - (pyver.stdout is version('3.8', '<'))
+    - (pyver.stdout | trim is version('3.8', '<'))
 
 - name: SUSE/SLES | ensure python311
   raw: |
@@ -59,7 +59,7 @@
     zypper -n install -y python311 || true
   when: 
     - (_os_id in ['sles','suse','opensuse-leap','opensuse'] or 'suse' in _os_like)
-    - (pyver.stdout is version('3.8', '<'))
+    - (pyver.stdout | trim is version('3.8', '<'))
 
 - name: Discover best Python interpreter path
   raw: |


### PR DESCRIPTION
Two latent bugs that surface intermittently:

1. **Setup role version check fails on repeated invocations** — the `raw` module stdout captures trailing whitespace/shell noise on subsequent SSH connections after K3s install. The `version()` Jinja2 filter chokes on the dirty string. Fixed by adding `| trim` to all `pyver.stdout` and `osr.stdout` references.

2. **Global role binding fails when rancher-webhook isn't ready** — on fresh Rancher installs the webhook pod may not have endpoints yet, causing a 500 on the globalrolebindings POST. Added retries with delay.