### PR TITLE
Dashboard - Fix Rancher head version sort and macOS docker detection

### DIFF
--- a/ansible/testing/dashboard-e2e/run.sh
+++ b/ansible/testing/dashboard-e2e/run.sh
@@ -36,6 +36,16 @@ VARS_FILE="${SCRIPT_DIR}/vars.yaml"
 
 # --- Detect container runtime ---
 detect_runtime() {
+	# Docker Desktop on macOS installs its CLI under ~/.docker/bin, which is not
+	# always on PATH (e.g. when the shell is managed outside Docker's installer).
+	# Add it so `command -v docker` can find it.
+	if [ -x "${HOME}/.docker/bin/docker" ]; then
+		case ":${PATH}:" in
+		*":${HOME}/.docker/bin:"*) ;;
+		*) PATH="${HOME}/.docker/bin:${PATH}" ;;
+		esac
+	fi
+
 	if command -v podman >/dev/null 2>&1; then
 		RUNTIME="podman"
 	elif command -v docker >/dev/null 2>&1; then
@@ -72,12 +82,17 @@ detect_socket() {
 		echo "  macOS:  podman machine start" >&2
 		exit 1
 	else
-		SOCKET="/var/run/docker.sock"
-		if [ ! -S "$SOCKET" ]; then
-			echo "ERROR: Docker socket not found at $SOCKET" >&2
-			echo "Is Docker running?" >&2
-			exit 1
-		fi
+		for _sock in \
+			"/var/run/docker.sock" \
+			"${HOME}/.docker/run/docker.sock"; do
+			if [ -S "$_sock" ]; then
+				SOCKET="$_sock"
+				return
+			fi
+		done
+		echo "ERROR: Docker socket not found at /var/run/docker.sock or ${HOME}/.docker/run/docker.sock" >&2
+		echo "Is Docker running?" >&2
+		exit 1
 	fi
 }
 

--- a/ansible/testing/dashboard-e2e/tasks/resolve-helm-version.yml
+++ b/ansible/testing/dashboard-e2e/tasks/resolve-helm-version.yml
@@ -73,8 +73,12 @@
 
       case "${TAG}" in
         head)
-          echo "${SEARCH}" | sed -n '1!p' | head -1 \
-            | awk '{print $2}' | tr -d '[:space:]'
+          # Use version sort, not helm's order: helm sorts pre-release
+          # identifiers lexically, so 2.x-alpha9 ranks above 2.x-alpha14
+          # ('9' > '1') and a plain `head -1` would pick a stale alpha.
+          # `sort -V` gives the true newest chart version.
+          echo "${SEARCH}" | sed -n '1!p' \
+            | awk '{print $2}' | sort -V | tail -1 | tr -d '[:space:]'
           ;;
         *)
           case "{{ rancher_helm_repo }}" in


### PR DESCRIPTION
Use sort -V for the head tag so the newest alpha wins instead of helm's lexical order picking a stale one. Also detect Docker Desktop's CLI and socket paths on macOS, with Linux still using /var/run/docker.sock.