### PR TITLE
Add airgap multi-cluster support and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 *.tfvars
 *.tfstate
 *.tfstate.backup
+*.tfstate.*.backup
+*.tfstate.*
 .terraform
 *terraform.tfstate.d
 .terraform.tfstate.lock.info

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ help: ## Show this help message
 	@echo "  ENV      = $(ENV)     (options: airgap, default, proxy)"
 	@echo "  PROVIDER = $(PROVIDER)       (options: aws, gcp, harvester)"
 	@echo "  WORKSPACE = $(WORKSPACE)    (tofu workspace name)"
-	@echo "  TARGET_GROUP = $(if $(TARGET_GROUP),$(TARGET_GROUP),<unset>)  (airgap node group: rancher, downstream)"
+	@echo "  TARGET_GROUP = $(if $(TARGET_GROUP),$(TARGET_GROUP),<unset>)  (airgap node group, e.g. rancher/downstream; required for 'downstream')"
 	@echo ""
 	@echo "Override with: make <target> DISTRO=k3s ENV=default PROVIDER=aws WORKSPACE=myworkspace"
 	@echo "At the moment this only supports rke2, default/airgap, and aws"
@@ -122,7 +122,7 @@ help: ## Show this help message
 	@echo "  agents              Setup additional agent nodes"
 	@echo "  registry            Configure private registry on cluster nodes"
 	@echo "  rancher             Deploy Rancher to cluster"
-	@echo "  downstream          Register an airgap cluster into Rancher (ENV=airgap, TARGET_GROUP=downstream)"
+	@echo "  downstream          Register an airgap cluster into Rancher (requires ENV=airgap and TARGET_GROUP=downstream)"
 	@echo "  upgrade-cluster     Upgrade Kubernetes cluster"
 	@echo "  kubectl-setup       Setup kubectl access on bastion"
 	@echo ""
@@ -557,9 +557,14 @@ kubectl-setup: check-inventory ## Setup kubectl access on bastion
 	ansible-playbook -i $(INVENTORY) ansible/$(DISTRO)/shared/playbooks/setup/setup-kubectl-access.yml -v $(ANSIBLE_EXTRA_VARS)
 
 .PHONY: downstream
-downstream: check-inventory ## Register an existing airgap cluster into Rancher as a downstream (ENV=airgap, TARGET_GROUP=downstream)
+downstream: check-inventory ## Register an existing airgap cluster into Rancher as a downstream (requires ENV=airgap and TARGET_GROUP, e.g. TARGET_GROUP=downstream)
 	@if [ "$(ENV)" != "airgap" ]; then \
 		echo "ERROR: 'downstream' target only applies to ENV=airgap"; exit 1; \
+	fi
+	@if [ -z "$(TARGET_GROUP)" ]; then \
+		echo "ERROR: 'downstream' requires TARGET_GROUP (the inventory group of the cluster to register into Rancher)."; \
+		echo "       Example: make downstream ENV=airgap TARGET_GROUP=downstream"; \
+		exit 1; \
 	fi
 	@if [ -z "$(DOWNSTREAM_PLAYBOOK)" ] || [ ! -f "$(DOWNSTREAM_PLAYBOOK)" ]; then \
 		echo "ERROR: downstream playbook not found: $(DOWNSTREAM_PLAYBOOK)"; exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -654,16 +654,20 @@ airgap-downstream: check-inventory ## Full airgap multi-cluster: downstream RKE2
 		echo "ERROR: 'airgap-downstream' requires ENV=airgap"; exit 1; \
 	fi
 	@echo ""
-	@echo "==> [1/4] Installing $(DISTRO) on downstream group..."
+	@echo "==> [1/5] Installing $(DISTRO) on downstream group..."
 	@$(MAKE) cluster DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=downstream
 	@echo ""
-	@echo "==> [2/4] Installing $(DISTRO) on rancher group..."
+	@echo "==> [2/5] Configuring private registry on downstream group..."
+	@export ANSIBLE_CONFIG=$(ANSIBLE_DIR)/ansible.cfg; \
+		ansible-playbook -i $(INVENTORY) $(ANSIBLE_DIR)/playbooks/deploy/$(DISTRO)-registry-config-playbook.yml -e target=downstream -v $(ANSIBLE_EXTRA_VARS)
+	@echo ""
+	@echo "==> [3/5] Installing $(DISTRO) on rancher group..."
 	@$(MAKE) cluster DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=rancher
 	@echo ""
-	@echo "==> [3/4] Deploying Rancher on rancher group..."
+	@echo "==> [4/5] Deploying Rancher on rancher group..."
 	@$(MAKE) rancher DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=
 	@echo ""
-	@echo "==> [4/4] Registering downstream cluster into Rancher..."
+	@echo "==> [5/5] Registering downstream cluster into Rancher..."
 	@$(MAKE) downstream DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=downstream
 	@echo ""
 	@echo "Airgap Rancher + downstream cluster setup complete!"

--- a/Makefile
+++ b/Makefile
@@ -566,7 +566,7 @@ downstream: check-inventory ## Register an existing airgap cluster into Rancher 
 	fi
 	@echo "Registering '$(TARGET_GROUP)' cluster into Rancher as downstream..."
 	@export ANSIBLE_CONFIG=$(ANSIBLE_DIR)/ansible.cfg; \
-	ansible-playbook -i $(INVENTORY) $(DOWNSTREAM_PLAYBOOK) -v $(TARGET_EXTRA_VARS) $(ANSIBLE_EXTRA_VARS)
+	ansible-playbook -i $(INVENTORY) $(DOWNSTREAM_PLAYBOOK) -v $(ANSIBLE_EXTRA_VARS) $(TARGET_EXTRA_VARS)
 
 # ============================================================================
 # UTILITIES

--- a/Makefile
+++ b/Makefile
@@ -670,6 +670,8 @@ airgap-downstream: check-inventory ## Full airgap multi-cluster: downstream RKE2
 	@$(MAKE) cluster DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=rancher
 	@echo ""
 	@echo "==> [4/5] Deploying Rancher on rancher group..."
+	# Intentionally clear TARGET_GROUP so the Rancher deploy step never inherits a
+	# stray target group from the command line or an earlier step in this flow.
 	@$(MAKE) rancher DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=
 	@echo ""
 	@echo "==> [5/5] Registering downstream cluster into Rancher..."

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,12 @@ SHELL := /bin/bash
 DISTRO       ?= rke2
 ENV          ?= default
 PROVIDER     ?= aws
-WORKSPACE    ?= default
+WORKSPACE     ?= default
+# Target inventory group for airgap cluster installs (e.g. rancher, downstream).
+# Leave empty to use each playbook's default (rancher).
+TARGET_GROUP  ?=
 # Set AUTO_APPROVE=yes to skip interactive confirmation prompts (for CI use)
-AUTO_APPROVE ?= no
+AUTO_APPROVE  ?= no
 
 # Derived paths
 ANSIBLE_DIR := ansible/$(DISTRO)/$(ENV)
@@ -28,15 +31,24 @@ CLUSTER_PLAYBOOK := $(ANSIBLE_DIR)/$(DISTRO)-playbook.yml
 RANCHER_PLAYBOOK := ansible/rancher/default-ha/rancher-playbook.yml
 REGISTRY_TARGET  :=
 else ifeq ($(ENV),airgap)
-TOFU_DIR         := tofu/$(PROVIDER)/modules/$(ENV)
-CLUSTER_PLAYBOOK := $(ANSIBLE_DIR)/playbooks/deploy/$(DISTRO)-tarball-playbook.yml
-RANCHER_PLAYBOOK := ansible/$(DISTRO)/shared/playbooks/deploy/rancher-helm-deploy-playbook.yml
-REGISTRY_TARGET  := registry
+TOFU_DIR            := tofu/$(PROVIDER)/modules/$(ENV)
+CLUSTER_PLAYBOOK    := $(ANSIBLE_DIR)/playbooks/deploy/$(DISTRO)-tarball-playbook.yml
+RANCHER_PLAYBOOK    := ansible/$(DISTRO)/shared/playbooks/deploy/rancher-helm-deploy-playbook.yml
+DOWNSTREAM_PLAYBOOK := $(ANSIBLE_DIR)/playbooks/deploy/add-downstream-cluster.yml
+REGISTRY_TARGET     := registry
 else
 TOFU_DIR         := tofu/$(PROVIDER)/modules/$(ENV)
 CLUSTER_PLAYBOOK := $(ANSIBLE_DIR)/playbooks/deploy/$(DISTRO)-install-playbook.yml
 RANCHER_PLAYBOOK := ansible/$(DISTRO)/shared/playbooks/deploy/rancher-helm-deploy-playbook.yml
 REGISTRY_TARGET  :=
+endif
+
+# Extra --extra-vars for selecting a target inventory group (airgap multi-cluster).
+# Applies to targets that install on a node group (cluster, downstream).
+ifdef TARGET_GROUP
+TARGET_EXTRA_VARS := --extra-vars "target=$(TARGET_GROUP)"
+else
+TARGET_EXTRA_VARS :=
 endif
 
 # Kubeconfig written by the cluster role; rancher needs to know where it is.
@@ -65,6 +77,7 @@ help: ## Show this help message
 	@echo "  ENV      = $(ENV)     (options: airgap, default, proxy)"
 	@echo "  PROVIDER = $(PROVIDER)       (options: aws, gcp, harvester)"
 	@echo "  WORKSPACE = $(WORKSPACE)    (tofu workspace name)"
+	@echo "  TARGET_GROUP = $(if $(TARGET_GROUP),$(TARGET_GROUP),<unset>)  (airgap node group: rancher, downstream)"
 	@echo ""
 	@echo "Override with: make <target> DISTRO=k3s ENV=default PROVIDER=aws WORKSPACE=myworkspace"
 	@echo "At the moment this only supports rke2, default/airgap, and aws"
@@ -109,6 +122,7 @@ help: ## Show this help message
 	@echo "  agents              Setup additional agent nodes"
 	@echo "  registry            Configure private registry on cluster nodes"
 	@echo "  rancher             Deploy Rancher to cluster"
+	@echo "  downstream          Register an airgap cluster into Rancher (ENV=airgap, TARGET_GROUP=downstream)"
 	@echo "  upgrade-cluster     Upgrade Kubernetes cluster"
 	@echo "  kubectl-setup       Setup kubectl access on bastion"
 	@echo ""
@@ -124,10 +138,12 @@ help: ## Show this help message
 	@echo "COMBINED WORKFLOWS:"
 	@echo "  all                 Full setup: infrastructure + cluster + Rancher"
 	@echo "  setup-from-infra    Setup cluster + Rancher (infra already exists)"
+	@echo "  airgap-downstream   Airgap: downstream+ rancher RKE2, Rancher, then register downstream"
 	@echo ""
 	@echo "EXAMPLES:"
 	@echo "  make all                                    # RKE2 default on AWS (default)"
 	@echo "  make all ENV=airgap                         # RKE2 airgap on AWS"
+	@echo "  make airgap-downstream ENV=airgap           # Airgap Rancher + downstream cluster"
 	@echo "  make all DISTRO=k3s                         # K3s default on AWS"
 	@echo "  make cluster ENV=airgap                     # Just RKE2 airgap cluster"
 	@echo "  make status                                 # Check current cluster"
@@ -505,10 +521,10 @@ bootstrap-python: check-inventory ## Bootstrap Python 3.9+ on target nodes
 	ansible-playbook -i $(INVENTORY) ansible/$(DISTRO)/shared/bootstrap-python.yml -v $(ANSIBLE_EXTRA_VARS)
 
 .PHONY: cluster
-cluster: check-inventory bootstrap-python ## Install Kubernetes cluster
-	@echo "Installing $(DISTRO) cluster ($(ENV) environment)..."
+cluster: check-inventory bootstrap-python ## Install Kubernetes cluster (use TARGET_GROUP=downstream for airgap multi-cluster)
+	@echo "Installing $(DISTRO) cluster ($(ENV) environment$(if $(TARGET_GROUP), on '$(TARGET_GROUP)' group,))..."
 	@export ANSIBLE_CONFIG=$(ANSIBLE_DIR)/ansible.cfg; \
-	ansible-playbook -i $(INVENTORY) $(CLUSTER_PLAYBOOK) -v $(ANSIBLE_EXTRA_VARS)
+	ansible-playbook -i $(INVENTORY) $(CLUSTER_PLAYBOOK) -v $(ANSIBLE_EXTRA_VARS) $(TARGET_EXTRA_VARS)
 
 .PHONY: agents
 agents: check-inventory ## Setup additional agent nodes
@@ -539,6 +555,18 @@ kubectl-setup: check-inventory ## Setup kubectl access on bastion
 	@echo "Setting up kubectl access..."
 	@export ANSIBLE_CONFIG=$(ANSIBLE_DIR)/ansible.cfg; \
 	ansible-playbook -i $(INVENTORY) ansible/$(DISTRO)/shared/playbooks/setup/setup-kubectl-access.yml -v $(ANSIBLE_EXTRA_VARS)
+
+.PHONY: downstream
+downstream: check-inventory ## Register an existing airgap cluster into Rancher as a downstream (ENV=airgap, TARGET_GROUP=downstream)
+	@if [ "$(ENV)" != "airgap" ]; then \
+		echo "ERROR: 'downstream' target only applies to ENV=airgap"; exit 1; \
+	fi
+	@if [ -z "$(DOWNSTREAM_PLAYBOOK)" ] || [ ! -f "$(DOWNSTREAM_PLAYBOOK)" ]; then \
+		echo "ERROR: downstream playbook not found: $(DOWNSTREAM_PLAYBOOK)"; exit 1; \
+	fi
+	@echo "Registering '$(TARGET_GROUP)' cluster into Rancher as downstream..."
+	@export ANSIBLE_CONFIG=$(ANSIBLE_DIR)/ansible.cfg; \
+	ansible-playbook -i $(INVENTORY) $(DOWNSTREAM_PLAYBOOK) -v $(TARGET_EXTRA_VARS) $(ANSIBLE_EXTRA_VARS)
 
 # ============================================================================
 # UTILITIES
@@ -619,6 +647,26 @@ setup-from-infra: check-inventory cluster $(REGISTRY_TARGET) rancher ## Setup cl
 	@echo "$(DISTRO) cluster and Rancher setup complete!"
 	@echo ""
 	@$(MAKE) status DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER)
+
+.PHONY: airgap-downstream
+airgap-downstream: check-inventory ## Full airgap multi-cluster: downstream RKE2 + rancher RKE2 + Rancher + register downstream
+	@if [ "$(ENV)" != "airgap" ]; then \
+		echo "ERROR: 'airgap-downstream' requires ENV=airgap"; exit 1; \
+	fi
+	@echo ""
+	@echo "==> [1/4] Installing $(DISTRO) on downstream group..."
+	@$(MAKE) cluster DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=downstream
+	@echo ""
+	@echo "==> [2/4] Installing $(DISTRO) on rancher group..."
+	@$(MAKE) cluster DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=rancher
+	@echo ""
+	@echo "==> [3/4] Deploying Rancher on rancher group..."
+	@$(MAKE) rancher DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=
+	@echo ""
+	@echo "==> [4/4] Registering downstream cluster into Rancher..."
+	@$(MAKE) downstream DISTRO=$(DISTRO) ENV=$(ENV) PROVIDER=$(PROVIDER) TARGET_GROUP=downstream
+	@echo ""
+	@echo "Airgap Rancher + downstream cluster setup complete!"
 
 # ============================================================================
 # DEBUG

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ make all    # provisions infra → deploys RKE2 → installs Rancher
 
 For an airgap deployment: `make all ENV=airgap`. For K3s: `make all DISTRO=k3s`.
 
+To provision an airgap Rancher **and** register a downstream cluster in one go:
+
+```bash
+# 1. Configure  tofu/aws/modules/airgap/terraform.tfvars  with node_groups = { rancher = 3, downstream = 3 }
+# 2. Configure  ansible/rke2/airgap/inventory/group_vars/all.yml
+
+make airgap-downstream ENV=airgap    # RKE2 on both groups → Rancher → register downstream
+```
+
+See the [import cluster on airgap guide](docs/import_cluster_on_airgap.md) for details.
+
 See [prerequisites](docs/prerequisites.md) first.
 
 ## Documentation

--- a/ansible/rke2/airgap/playbooks/deploy/add-downstream-cluster.yml
+++ b/ansible/rke2/airgap/playbooks/deploy/add-downstream-cluster.yml
@@ -7,11 +7,14 @@
     repo_root: "{{ playbook_dir | regex_replace('(.*)/ansible/.*', '\\1') }}"
     fqdn: "{{ rancher_hostname | default(external_lb_hostname) }}"
     # Cluster name generation: <prefix>-<random suffix>
-    # Override prefix via `downstream_cluster_name_prefix` var or DOWNSTREAM_CLUSTER_NAME_PREFIX env.
-    # Override suffix length via `downstream_cluster_name_suffix_length` (default 8).
+    # Precedence for the prefix (highest first): `downstream_cluster_name_prefix` (e.g. set in inventory/group_vars),
+    # `DOWNSTREAM_CLUSTER_NAME_PREFIX` env, then the hardcoded 'ansible-created' below.
+    # Suffix length: override via `downstream_cluster_name_suffix_length` (default 8).
     # Set DOWNSTREAM_CLUSTER_NAME (or `cluster_name`) to use a fully custom name instead.
-    downstream_cluster_name_prefix: "{{ lookup('env', 'DOWNSTREAM_CLUSTER_NAME_PREFIX') | default('ansible-created', true) }}"
-    downstream_cluster_name_suffix_length: 8
+    # NOTE: defined as `*_default` play vars (not the override names) so inventory/group_vars/host_vars
+    # can override them — play-level `vars:` otherwise outrank inventory vars.
+    downstream_cluster_name_prefix_default: "{{ lookup('env', 'DOWNSTREAM_CLUSTER_NAME_PREFIX') | default('ansible-created', true) }}"
+    downstream_cluster_name_suffix_length_default: 8
   pre_tasks:
     - name: Validate rancher group exists
       ansible.builtin.assert:
@@ -59,7 +62,7 @@
 
     - name: Generate cluster name as <prefix>-<random suffix> when not explicitly set
       ansible.builtin.set_fact:
-        cluster_name: "{{ downstream_cluster_name_prefix }}-{{ lookup('password', '/dev/null length=' ~ downstream_cluster_name_suffix_length ~ ' chars=ascii_lowercase,digits') }}"
+        cluster_name: "{{ downstream_cluster_name_prefix | default(downstream_cluster_name_prefix_default) }}-{{ lookup('password', '/dev/null length=' ~ (downstream_cluster_name_suffix_length | default(downstream_cluster_name_suffix_length_default)) ~ ' chars=ascii_lowercase,digits') }}"
       when: cluster_name | default('', true) | length == 0
 
     - name: Display generated cluster name

--- a/ansible/rke2/airgap/playbooks/deploy/add-downstream-cluster.yml
+++ b/ansible/rke2/airgap/playbooks/deploy/add-downstream-cluster.yml
@@ -89,6 +89,50 @@
         cluster_id: "{{ (tofu_outputs_json.stdout | from_json).cluster_id.value }}"
         cluster_registration_token: "{{ (tofu_outputs_json.stdout | from_json).cluster_registration_token.value }}"
 
+    # Optionally inject the downstream cluster name into cattle-config.yaml.
+    # Mirrors generate-admin-token.yml's rancher_auth role, which writes
+    # rancher.adminToken when rancher_cattle_config_file is set.
+    - name: Update cattle-config.yaml with downstream cluster name
+      when: rancher_cattle_config_file | default('') | length > 0
+      block:
+        - name: Check if cattle config file exists
+          ansible.builtin.stat:
+            path: "{{ rancher_cattle_config_file }}"
+          register: cattle_config_stat
+
+        - name: Fail if cattle config file doesn't exist
+          ansible.builtin.fail:
+            msg: "Cattle config file not found: {{ rancher_cattle_config_file }}"
+          when: not cattle_config_stat.stat.exists
+
+        - name: Read existing cattle config
+          ansible.builtin.slurp:
+            src: "{{ rancher_cattle_config_file }}"
+          register: cattle_config_content
+
+        - name: Parse cattle config YAML
+          ansible.builtin.set_fact:
+            cattle_config: "{{ cattle_config_content.content | b64decode | from_yaml }}"
+
+        - name: Update cattle config with downstream cluster name
+          ansible.builtin.set_fact:
+            cattle_config_updated: >-
+              {{ cattle_config | combine({
+                'rancher': (cattle_config.rancher | default({})) | combine({
+                  'clusterName': cluster_name
+                })
+              }, recursive=True) }}
+
+        - name: Write updated cattle config
+          ansible.builtin.copy:
+            content: "{{ cattle_config_updated | to_nice_yaml(indent=2) }}"
+            dest: "{{ rancher_cattle_config_file }}"
+            mode: '0644'
+
+        - name: Display cattle config update status
+          ansible.builtin.debug:
+            msg: "Updated {{ rancher_cattle_config_file }} with clusterName: {{ cluster_name }}"
+
 - hosts: bastion
   gather_facts: true
   become: true

--- a/ansible/rke2/airgap/playbooks/deploy/add-downstream-cluster.yml
+++ b/ansible/rke2/airgap/playbooks/deploy/add-downstream-cluster.yml
@@ -6,6 +6,12 @@
     admin_password: "{{ rancher_bootstrap_password | default('admin') }}"
     repo_root: "{{ playbook_dir | regex_replace('(.*)/ansible/.*', '\\1') }}"
     fqdn: "{{ rancher_hostname | default(external_lb_hostname) }}"
+    # Cluster name generation: <prefix>-<random suffix>
+    # Override prefix via `downstream_cluster_name_prefix` var or DOWNSTREAM_CLUSTER_NAME_PREFIX env.
+    # Override suffix length via `downstream_cluster_name_suffix_length` (default 8).
+    # Set DOWNSTREAM_CLUSTER_NAME (or `cluster_name`) to use a fully custom name instead.
+    downstream_cluster_name_prefix: "{{ lookup('env', 'DOWNSTREAM_CLUSTER_NAME_PREFIX') | default('ansible-created', true) }}"
+    downstream_cluster_name_suffix_length: 8
   pre_tasks:
     - name: Validate rancher group exists
       ansible.builtin.assert:
@@ -47,14 +53,18 @@
       delay: 10
       until: token_response.status == 201
 
-    - name: Get cluster name from environment variable
+    - name: Get cluster name from explicit variable or environment
       ansible.builtin.set_fact:
-        cluster_name: "{{ lookup('env', 'DOWNSTREAM_CLUSTER_NAME') | default('', true) }}"
+        cluster_name: "{{ cluster_name | default(lookup('env', 'DOWNSTREAM_CLUSTER_NAME'), true) }}"
 
-    - name: Generate cluster name if DOWNSTREAM_CLUSTER_NAME is empty
+    - name: Generate cluster name as <prefix>-<random suffix> when not explicitly set
       ansible.builtin.set_fact:
-        cluster_name: "ansible-created-{{ lookup('password', '/dev/null length=8 chars=ascii_lowercase,digits') }}"
-      when: cluster_name == ''
+        cluster_name: "{{ downstream_cluster_name_prefix }}-{{ lookup('password', '/dev/null length=' ~ downstream_cluster_name_suffix_length ~ ' chars=ascii_lowercase,digits') }}"
+      when: cluster_name | default('', true) | length == 0
+
+    - name: Display generated cluster name
+      ansible.builtin.debug:
+        msg: "Downstream cluster name: {{ cluster_name }}"
 
     - name: Create generic imported cluster with OpenTofu
       ansible.builtin.shell: |

--- a/ansible/roles/rancher_auth/tasks/main.yml
+++ b/ansible/roles/rancher_auth/tasks/main.yml
@@ -269,7 +269,8 @@
         cattle_config_updated: >-
           {{ cattle_config | combine({
             'rancher': (cattle_config.rancher | default({})) | combine({
-              'adminToken': rancher_api_token
+              'adminToken': rancher_api_token,
+              'host': rancher_url_normalized | regex_replace('^https?://', '')
             })
           }, recursive=True) }}
 
@@ -282,7 +283,7 @@
 
     - name: Display cattle config update status
       ansible.builtin.debug:
-        msg: "Updated {{ rancher_cattle_config_file }} with adminToken"
+        msg: "Updated {{ rancher_cattle_config_file }} with adminToken and host"
 
 # Step 7: Clean up temporary login token
 # The login API creates a session token (~15h TTL) that is only needed during this

--- a/ansible/roles/rancher_auth/tasks/main.yml
+++ b/ansible/roles/rancher_auth/tasks/main.yml
@@ -284,6 +284,7 @@
     - name: Display cattle config update status
       ansible.builtin.debug:
         msg: "Updated {{ rancher_cattle_config_file }} with adminToken and host"
+      when: ansible_verbosity >= 1
 
 # Step 7: Clean up temporary login token
 # The login API creates a session token (~15h TTL) that is only needed during this

--- a/docs/guides/rke2-airgap-aws.md
+++ b/docs/guides/rke2-airgap-aws.md
@@ -192,7 +192,7 @@ For more, see the [airgap troubleshooting section](../../ansible/rke2/airgap/REA
 
 ## Next Steps
 
-- [Import a downstream cluster](../../docs/import_cluster_on_airgap.md) into an airgapped Rancher
+- **[Import a downstream cluster](../import_cluster_on_airgap.md)** into an airgapped Rancher — now a single command: `make airgap-downstream ENV=airgap`
 - [Upgrade RKE2](../../ansible/rke2/airgap/docs/configuration/RKE2_UPGRADE_GUIDE.md) in an airgap environment
 - [CNI configuration options](../../ansible/rke2/airgap/docs/configuration/CNI_CONFIGURATION_GUIDE.md)
 - [Full airgap reference](../../ansible/rke2/airgap/README.md)

--- a/docs/import_cluster_on_airgap.md
+++ b/docs/import_cluster_on_airgap.md
@@ -12,6 +12,12 @@ The RKE2 upgrade process for airgap environments involves:
 
 ## Process
 
+> **Makefile shortcuts:** This entire workflow can be run with a single command:
+> ```bash
+> make airgap-downstream ENV=airgap
+> ```
+> Or step-by-step using individual targets (see the `make` equivalents in each step below).
+
 ### 1. Provision nodes
 
 Run `tofu apply -var-file="terraform.tfvars"` with the desired `*.tfvars` file. This content can be used as a template:
@@ -53,8 +59,13 @@ ssh-add "<path_to_private_key>"
 Then we install RKE2 in both groups of nodes:
 
 ```bash
-ansible-playbook -i inventory/inventory.yml playbooks/deploy/rke2-tarball-playbook.yml --extra-vars="target=downstream" # Install RKE2 on the downstream cluster nodes
-ansible-playbook -i inventory/inventory.yml playbooks/deploy/rke2-tarball-playbook.yml # Group "rancher" is the default target group.
+# Makefile shortcut (recommended):
+make cluster ENV=airgap TARGET_GROUP=downstream  # Install RKE2 on the downstream cluster nodes
+make cluster ENV=airgap TARGET_GROUP=rancher      # Install RKE2 on the rancher cluster nodes (default group)
+
+# Raw Ansible equivalent:
+ansible-playbook -i inventory/inventory.yml playbooks/deploy/rke2-tarball-playbook.yml --extra-vars="target=downstream"
+ansible-playbook -i inventory/inventory.yml playbooks/deploy/rke2-tarball-playbook.yml  # Group "rancher" is the default target group.
 ```
 
 Mind that, since we provisioned two groups of nodes, running this playbook without `--extra-vars` will default to installing on the nodes of group named `rancher`.
@@ -70,6 +81,10 @@ ansible-playbook -i inventory/inventory.yml playbooks/setup/setup-kubectl-access
 Use the appropriate playbook to install Rancher on the appropriate nodes:
 
 ```bash
+# Makefile shortcut (recommended):
+make rancher ENV=airgap
+
+# Raw Ansible equivalent:
 ansible-playbook -i inventory/inventory.yml playbooks/deploy/rancher-helm-deploy-playbook.yml
 ```
 
@@ -80,6 +95,10 @@ The use of additional flags is not needed here because this playbook will be app
 Use the appropriate playbook to add the configured downstream cluster to the configured Rancher instance.
 
 ```bash
+# Makefile shortcut (recommended):
+make downstream ENV=airgap TARGET_GROUP=downstream
+
+# Raw Ansible equivalent:
 ansible-playbook -i inventory/inventory.yml playbooks/deploy/add-downstream-cluster.yml --extra-vars="target=downstream"
 ```
 

--- a/docs/reference/makefile.md
+++ b/docs/reference/makefile.md
@@ -12,6 +12,7 @@ Override these with `make <target> VAR=value`:
 | `ENV` | `default` | `default`, `airgap`, `proxy` | Deployment environment |
 | `PROVIDER` | `aws` | `aws`, `gcp`, `harvester` | Infrastructure provider |
 | `EXTRA_VARS` | (empty) | any | Extra Ansible variables passed with `--extra-vars` |
+| `TARGET_GROUP` | (empty) | `rancher`, `downstream`, any group | Airgap inventory group to target (translates to `--extra-vars target=<group>`) |
 
 **Example:**
 
@@ -41,6 +42,7 @@ make all DISTRO=k3s ENV=default PROVIDER=aws
 | `make agents` | Set up additional agent nodes (airgap) |
 | `make registry` | Configure private registry on cluster nodes (airgap) |
 | `make rancher` | Deploy Rancher onto the cluster |
+| `make downstream` | Register an existing airgap cluster into Rancher as a downstream (`ENV=airgap` only; use `TARGET_GROUP=` to name the group) |
 | `make upgrade-cluster` | Upgrade Kubernetes version |
 | `make kubectl-setup` | Set up kubectl on the bastion host (airgap) |
 
@@ -64,6 +66,7 @@ make all DISTRO=k3s ENV=default PROVIDER=aws
 |--------|-------------|
 | `make all` | Full setup: infra-up → cluster → rancher |
 | `make setup-from-infra` | Cluster + rancher (infra already exists) |
+| `make airgap-downstream` | Airgap multi-cluster: RKE2 on `downstream` + `rancher` groups, deploy Rancher, register downstream (`ENV=airgap` only) |
 
 ## Common Invocations
 
@@ -94,6 +97,15 @@ make infra-nuke
 
 # Pass extra Ansible variables
 make cluster EXTRA_VARS="kubernetes_version=v1.34.2+rke2r1"
+
+# Airgap: install RKE2 on a specific node group
+make cluster ENV=airgap TARGET_GROUP=downstream
+
+# Airgap: full Rancher + downstream cluster workflow
+make airgap-downstream ENV=airgap
+
+# Airgap: register an already-running cluster into Rancher
+make downstream ENV=airgap TARGET_GROUP=downstream
 ```
 
 ## How Variables Determine Paths
@@ -109,4 +121,17 @@ For example, `DISTRO=rke2 ENV=airgap PROVIDER=aws` maps to:
 - Tofu: `tofu/aws/modules/airgap/`
 - Ansible: `ansible/rke2/airgap/`
 - Cluster playbook: `ansible/rke2/airgap/playbooks/deploy/rke2-tarball-playbook.yml`
-- Rancher playbook: `ansible/rke2/airgap/playbooks/deploy/rancher-helm-deploy-playbook.yml`
+- Rancher playbook: `ansible/rke2/shared/playbooks/deploy/rancher-helm-deploy-playbook.yml`
+- Downstream playbook: `ansible/rke2/airgap/playbooks/deploy/add-downstream-cluster.yml`
+
+## Airgap Multi-Cluster (`TARGET_GROUP`)
+
+Airgap deployments can provision multiple node groups (e.g. `rancher` + `downstream`) by setting `node_groups` in `terraform.tfvars`. The `TARGET_GROUP` variable selects which group a target operates on:
+
+| `TARGET_GROUP` value | Effect |
+|----------------------|--------|
+| (unset) | Use each playbook's default group (typically `rancher`) |
+| `rancher` | Explicitly target the `rancher` group |
+| `downstream` | Target the `downstream` group |
+
+The `make airgap-downstream` target orchestrates the full sequence (install RKE2 on both groups → deploy Rancher → register the downstream cluster). See [Import a downstream cluster on airgap](../import_cluster_on_airgap.md) for the complete guide.

--- a/docs/reference/makefile.md
+++ b/docs/reference/makefile.md
@@ -42,7 +42,7 @@ make all DISTRO=k3s ENV=default PROVIDER=aws
 | `make agents` | Set up additional agent nodes (airgap) |
 | `make registry` | Configure private registry on cluster nodes (airgap) |
 | `make rancher` | Deploy Rancher onto the cluster |
-| `make downstream` | Register an existing airgap cluster into Rancher as a downstream (`ENV=airgap` only; use `TARGET_GROUP=` to name the group) |
+| `make downstream` | Register an existing airgap cluster into Rancher as a downstream (`ENV=airgap` only; use `TARGET_GROUP=<group>`, e.g. `TARGET_GROUP=downstream`, to name the group) |
 | `make upgrade-cluster` | Upgrade Kubernetes version |
 | `make kubectl-setup` | Set up kubectl on the bastion host (airgap) |
 

--- a/tofu/rancher/import/.terraform.lock.hcl
+++ b/tofu/rancher/import/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/rancher2" {
+  version = "14.1.1"
+  hashes = [
+    "h1:XguC/YWN5PuuX+oQ9U7HZdrpLZ/z32XFTmWcTZTO/AY=",
+    "zh:11c4c34ba996b633d116e83f48b0baecaa1e0cbf50562abdfd9424cd6f6141a4",
+    "zh:205a3a4b5f078b2eeea06f4a13ab15bcf34864460f789568d384a03e47f0a009",
+    "zh:2dc7df1fc9c6bb23ca9b0be326aac125212d525cde029a3c44c943f82e07c59f",
+    "zh:50752ce808ff054c36e7a594bec9807299f3dbe2febf5ffa501239aa5a4b3125",
+    "zh:515d787138ba9a750506ccc45f95a707ccf6bd2601e6bcc732e39f18e1436837",
+    "zh:8b8ae8881596dc865e3998701ff0048ace2670a73c6ea990dcee0ea9ea8006bc",
+    "zh:a54086f41c125b7460b8cf1b588f778b8e971a131a8713cd12806e3724e198a8",
+    "zh:b346815aac1ba419e12210fc03da57cc8606366a5817c6fbb7ce84bc26a65ef0",
+    "zh:c8b5fae14df8195c3ab21781913f929d3db2f4576d9b6ed5353b663d9f6b7940",
+    "zh:d990f1b187d1c6779d38a2620c685b2c3efc79be4d603ed6b041ecbdfcc1e79b",
+  ]
+}

--- a/tofu/rancher/import/.terraform.lock.hcl
+++ b/tofu/rancher/import/.terraform.lock.hcl
@@ -1,8 +1,9 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.opentofu.org/hashicorp/rancher2" {
-  version = "14.1.1"
+provider "registry.opentofu.org/rancher/rancher2" {
+  version     = "14.1.1"
+  constraints = ">= 14.0.0"
   hashes = [
     "h1:XguC/YWN5PuuX+oQ9U7HZdrpLZ/z32XFTmWcTZTO/AY=",
     "zh:11c4c34ba996b633d116e83f48b0baecaa1e0cbf50562abdfd9424cd6f6141a4",

--- a/tofu/rancher/import/terraform.tf
+++ b/tofu/rancher/import/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.8.2"
+  required_providers {
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = ">= 14.0.0"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for airgap multi-cluster workflows, focusing on simplifying provisioning both Rancher and downstream clusters and registering downstream clusters in Rancher, all via Makefile targets. It also improves documentation and the flexibility of cluster naming for downstream registration. The changes enable a single-command workflow for airgap multi-cluster setups and clarify variable usage for targeting specific inventory groups.

**Makefile and Workflow Enhancements:**

* Added the `TARGET_GROUP` variable to the `Makefile` and supporting logic, allowing users to target specific inventory groups (such as `rancher` or `downstream`) for airgap multi-cluster deployments. This enables more flexible and explicit control over which group each playbook operates on. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R16-R18) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R46-R53)
* Introduced new Makefile targets: `downstream` (registers a downstream cluster into Rancher) and `airgap-downstream` (orchestrates a full airgap multi-cluster setup: installs RKE2 on both groups, deploys Rancher, and registers the downstream cluster). These targets include validation and improved help output. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R559-R570) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R651-R674) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R80) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R125) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R141-R146)

**Downstream Cluster Registration Improvements:**

* Enhanced the downstream cluster registration playbook (`add-downstream-cluster.yml`) to allow explicit cluster name control via variables or environment, and to support custom name prefixes and suffix lengths. This provides more predictable and customizable downstream cluster naming. [[1]](diffhunk://#diff-354bfd472383dc52933d8dd56856e6d23d81af996a675d64d44d9976625767bcR9-R14) [[2]](diffhunk://#diff-354bfd472383dc52933d8dd56856e6d23d81af996a675d64d44d9976625767bcL50-R67)

**Documentation Updates:**

* Updated documentation (`README.md`, `docs/import_cluster_on_airgap.md`, `docs/reference/makefile.md`, `docs/guides/rke2-airgap-aws.md`) to describe the new workflow, variables, and Makefile targets, including step-by-step and single-command instructions for airgap multi-cluster setups. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R41) [[2]](diffhunk://#diff-41740752ec431b35a23ec4f7fa53a102bef5346ad4ee2ba2fbb9b2a544afb748R15-R20) [[3]](diffhunk://#diff-41740752ec431b35a23ec4f7fa53a102bef5346ad4ee2ba2fbb9b2a544afb748L56-R67) [[4]](diffhunk://#diff-41740752ec431b35a23ec4f7fa53a102bef5346ad4ee2ba2fbb9b2a544afb748R84-R87) [[5]](diffhunk://#diff-41740752ec431b35a23ec4f7fa53a102bef5346ad4ee2ba2fbb9b2a544afb748R98-R101) [[6]](diffhunk://#diff-0464429f054497d4f31606eb09220e17c39ed3af7649a721e39e725572ed3e87R15) [[7]](diffhunk://#diff-0464429f054497d4f31606eb09220e17c39ed3af7649a721e39e725572ed3e87R45) [[8]](diffhunk://#diff-0464429f054497d4f31606eb09220e17c39ed3af7649a721e39e725572ed3e87R69) [[9]](diffhunk://#diff-0464429f054497d4f31606eb09220e17c39ed3af7649a721e39e725572ed3e87R100-R108) [[10]](diffhunk://#diff-0464429f054497d4f31606eb09220e17c39ed3af7649a721e39e725572ed3e87L112-R137) [[11]](diffhunk://#diff-931116fbd819a512bd1ccbccfc46e6a7bb1a7df3cd8b2dabe955280b34dd1397L195-R195)

**Dependency Management:**

* Added a `.terraform.lock.hcl` file for the `rancher/import` module, pinning the `rancher2` provider version for reproducible OpenTofu runs.