### PR TITLE
Dashboard - Add arm64 support and harden dashboard-e2e runner

### DIFF
--- a/ansible/testing/dashboard-e2e/files/Dockerfile.ci
+++ b/ansible/testing/dashboard-e2e/files/Dockerfile.ci
@@ -1,12 +1,24 @@
 # renovate: datasource=docker depName=cypress/factory
 FROM cypress/factory:7.3.1@sha256:beb1107f12f2b9a0950d15ee5188f4fe9f049c620960ce3440accacbbc659afa
 
+# Provided automatically by BuildKit; falls back to dpkg on legacy builders.
+ARG TARGETARCH
+
 # renovate: datasource=github-release-attachments depName=kubernetes/kubernetes
 ENV KUBECTL_VERSION=v1.33.10
 # renovate: datasource=github-release-attachments depName=kubernetes/kubernetes digestVersion=v1.33.10
-ENV KUBECTL_SUM=f156acb753ee4366789ab7a663916eb580e7ee1b9e449bc9b052181db524e3f5
+ENV KUBECTL_SUM_AMD64=f156acb753ee4366789ab7a663916eb580e7ee1b9e449bc9b052181db524e3f5
+ENV KUBECTL_SUM_ARM64=e9494229893ccddc81065275c0e5f21167518ab939f0e95aecb649fb4b41c112
 
-RUN wget -q "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -O /tmp/kubectl && \
+# Install kubectl for the build architecture. amd64 (Linux CI) and arm64
+# (Apple Silicon) are both verified against their pinned checksum.
+RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "${ARCH}" in \
+      amd64) KUBECTL_SUM="${KUBECTL_SUM_AMD64}" ;; \
+      arm64) KUBECTL_SUM="${KUBECTL_SUM_ARM64}" ;; \
+      *) echo "Unsupported arch: ${ARCH}" >&2; exit 1 ;; \
+    esac && \
+    wget -q "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" -O /tmp/kubectl && \
     echo "${KUBECTL_SUM}  /tmp/kubectl" | sha256sum -c - && \
     mv /tmp/kubectl /bin/kubectl && \
     chmod +x /bin/kubectl

--- a/ansible/testing/dashboard-e2e/files/cypress.sh
+++ b/ansible/testing/dashboard-e2e/files/cypress.sh
@@ -60,13 +60,24 @@ if [ -n "$TAGS" ]; then
 	fi
 fi
 
+# Google Chrome in the cypress/factory image is amd64-only, so it is absent on
+# arm64 runners (Apple Silicon under Docker Desktop). Fall back to Cypress's
+# bundled Electron, which is arm64-native. Override with CYPRESS_BROWSER.
+BROWSER="${CYPRESS_BROWSER:-chrome}"
+if [ "$BROWSER" = chrome ] &&
+	! command -v google-chrome >/dev/null 2>&1 &&
+	! command -v google-chrome-stable >/dev/null 2>&1; then
+	echo "[cypress.sh] Google Chrome not found (arch=$(uname -m)); falling back to --browser electron."
+	BROWSER=electron
+fi
+
 # Run Cypress and capture the exit code
 set +e
 
 if [ -n "$PERCY_TOKEN" ]; then
-	percy exec -q -- cypress run --browser "${CYPRESS_BROWSER:-chrome}" --config-file cypress/jenkins/cypress.config.jenkins.ts "${SPEC_ARG[@]}"
+	percy exec -q -- cypress run --browser "$BROWSER" --config-file cypress/jenkins/cypress.config.jenkins.ts "${SPEC_ARG[@]}"
 else
-	cypress run --browser "${CYPRESS_BROWSER:-chrome}" --config-file cypress/jenkins/cypress.config.jenkins.ts "${SPEC_ARG[@]}"
+	cypress run --browser "$BROWSER" --config-file cypress/jenkins/cypress.config.jenkins.ts "${SPEC_ARG[@]}"
 fi
 EXIT_CODE=$?
 set -e

--- a/ansible/testing/dashboard-e2e/run.sh
+++ b/ansible/testing/dashboard-e2e/run.sh
@@ -181,21 +181,36 @@ TAGS=""
 STREAM=""
 _FORCE_BUILD=""
 _BUILD_ONLY=""
+_EXCL=""
+
+# destroy and build run on their own; refuse to mix them with stage verbs so a
+# request like "provision destroy" can never silently drop or reorder stages.
+_conflict() {
+	echo "ERROR: '$1' cannot be combined with other commands." >&2
+	echo "Run './run.sh --help' for usage." >&2
+	exit 2
+}
 while [ $# -gt 0 ]; do
 	case "$1" in
 	provision | setup | test)
+		[ -n "$_EXCL" ] && _conflict "$_EXCL"
 		TAGS="${TAGS:+${TAGS},}$1"
 		shift
 		;;
 	stream)
+		[ -n "$_EXCL" ] && _conflict "$_EXCL"
 		STREAM=1
 		shift
 		;;
 	destroy)
+		{ [ -n "$TAGS" ] || [ -n "$STREAM" ] || [ -n "$_EXCL" ]; } && _conflict destroy
+		_EXCL=destroy
 		TAGS="cleanup,never"
 		shift
 		;;
 	build)
+		{ [ -n "$TAGS" ] || [ -n "$STREAM" ] || [ -n "$_EXCL" ]; } && _conflict build
+		_EXCL=build
 		_FORCE_BUILD=1
 		_BUILD_ONLY=1
 		shift
@@ -222,15 +237,29 @@ while [ $# -gt 0 ]; do
 		sed -n '2,/^$/s/^# //p' "$0"
 		exit 0
 		;;
-	*)
+	-*)
+		# Unknown flag: stop parsing and forward it (and the rest) to ansible.
 		break
+		;;
+	*)
+		echo "ERROR: unknown command '$1'." >&2
+		echo "Run './run.sh --help' for usage." >&2
+		exit 2
 		;;
 	esac
 done
 
-# stream without explicit stages defaults to setup,test
-if [ -n "$STREAM" ] && [ -z "$TAGS" ]; then
-	TAGS="setup,test"
+# stream without explicit stages defaults to setup,test.
+# When "provision" is requested (for example "stream provision"), the setup
+# stage must also run because stream_cypress needs the runner image that setup
+# builds. A bare "stream test" stays a fast reuse and is left untouched.
+if [ -n "$STREAM" ]; then
+	if [ -z "$TAGS" ]; then
+		TAGS="setup,test"
+	elif printf ',%s,' "$TAGS" | grep -q ',provision,' &&
+		! printf ',%s,' "$TAGS" | grep -q ',setup,'; then
+		TAGS="${TAGS},setup"
+	fi
 fi
 
 # Check vars.yaml

--- a/ansible/testing/dashboard-e2e/tasks/cleanup.yml
+++ b/ansible/testing/dashboard-e2e/tasks/cleanup.yml
@@ -5,11 +5,14 @@
 - name: Destroy tofu workspaces
   ansible.builtin.shell:
     cmd: |
-      set -eu
-      cd {{ tofu_module }}
+      set -u
+      cd {{ tofu_module }} || exit 1
       tofu workspace select {{ item.workspace }} 2>/dev/null || exit 0
-      tofu destroy -var-file="{{ outputs_dir }}/{{ item.workspace }}.tfvars" \
-        -auto-approve -no-color -input=false 2>&1 | tail -n 5
+      out="$(tofu destroy -var-file="{{ outputs_dir }}/{{ item.workspace }}.tfvars" \
+        -auto-approve -no-color -input=false 2>&1)"
+      rc=$?
+      printf '%s\n' "$out" | tail -n 20
+      exit "$rc"
   loop:
     - { workspace: customnode, condition: "{{ create_initial_clusters | bool }}" }
     - { workspace: importcluster, condition: "{{ create_initial_clusters | bool }}" }
@@ -17,8 +20,34 @@
   when: item.condition | bool
   loop_control:
     label: "{{ item.workspace }}"
-  changed_when: true
+  register: destroy_results
+  # Per-item stdout/rc are not exposed to changed_when/failed_when inside a
+  # loop, so honesty and failure handling are done in the two tasks below,
+  # where the fully populated destroy_results is in scope.
+  changed_when: false
   failed_when: false
+
+- name: Report workspaces that actually had resources destroyed
+  ansible.builtin.debug:
+    msg: "Destroyed workspace(s): {{ _destroyed }}"
+  vars:
+    _destroyed: >-
+      {{ destroy_results.results | selectattr('rc', 'defined')
+         | selectattr('rc', 'eq', 0) | selectattr('stdout', 'defined')
+         | rejectattr('stdout', 'search', '0 destroyed')
+         | map(attribute='item.workspace') | list }}
+  changed_when: _destroyed | length > 0
+  when: _destroyed | length > 0
+
+- name: Fail if any tofu destroy errored
+  ansible.builtin.fail:
+    msg: >-
+      tofu destroy failed for workspace(s):
+      {{ destroy_results.results | selectattr('rc', 'defined')
+         | selectattr('rc', 'ne', 0) | map(attribute='item.workspace') | list }}
+  when: >-
+    destroy_results.results | selectattr('rc', 'defined')
+    | selectattr('rc', 'ne', 0) | list | length > 0
 
 - name: Remove Docker image
   community.docker.docker_image:

--- a/ansible/testing/dashboard-e2e/tasks/provision.yml
+++ b/ansible/testing/dashboard-e2e/tasks/provision.yml
@@ -54,7 +54,7 @@
   register: tofu_rancher_result
   async: 600
   poll: 0
-  changed_when: true
+  changed_when: false
   when: job_type == 'recurring'
 
 - name: Write importcluster tfvars
@@ -89,7 +89,7 @@
   register: tofu_import_result
   async: 600
   poll: 0
-  changed_when: true
+  changed_when: false
   when: create_initial_clusters | bool
 
 - name: Write customnode tfvars
@@ -124,7 +124,7 @@
   register: tofu_custom_result
   async: 600
   poll: 0
-  changed_when: true
+  changed_when: false
   when: create_initial_clusters | bool
 
 - name: Wait for rancher-server tofu apply
@@ -135,6 +135,9 @@
   retries: 60
   delay: 10
   failed_when: tofu_rancher_status.finished | bool and tofu_rancher_status.rc | default(1) != 0
+  changed_when: >-
+    tofu_rancher_status.finished | bool and
+    '0 added, 0 changed, 0 destroyed' not in (tofu_rancher_status.stdout | default(''))
   when: job_type == 'recurring'
 
 - name: Wait for importcluster tofu apply
@@ -145,6 +148,9 @@
   retries: 60
   delay: 10
   failed_when: tofu_import_status.finished | bool and tofu_import_status.rc | default(1) != 0
+  changed_when: >-
+    tofu_import_status.finished | bool and
+    '0 added, 0 changed, 0 destroyed' not in (tofu_import_status.stdout | default(''))
   when: create_initial_clusters | bool
 
 - name: Wait for customnode tofu apply
@@ -155,6 +161,9 @@
   retries: 60
   delay: 10
   failed_when: tofu_custom_status.finished | bool and tofu_custom_status.rc | default(1) != 0
+  changed_when: >-
+    tofu_custom_status.finished | bool and
+    '0 added, 0 changed, 0 destroyed' not in (tofu_custom_status.stdout | default(''))
   when: create_initial_clusters | bool
 
 - name: Dump rancher-server cluster_nodes_json


### PR DESCRIPTION
Install kubectl for the build architecture (amd64/arm64) with pinned checksums so the runner image builds on Apple Silicon. Fall back to the bundled Electron browser when Google Chrome is absent (Chrome ships amd64 only).

Harden run.sh argument parsing: run the setup stage when 'stream provision' is used so the image is built before streaming, reject unknown commands, and make destroy and build mutually exclusive with stage verbs so a mistyped or mixed invocation can no longer silently run the full pipeline or reorder stages. Unknown flags are still forwarded to ansible.

Stop the cleanup destroy loop from swallowing tofu failures: capture the real tofu exit code through the tail pipe, then surface any non-zero rc in a dedicated post-loop task after every workspace has been attempted.

Report changed honestly for tofu apply and destroy instead of hardcoding changed: true, so no-op runs no longer show phantom changes.