### PR TITLE
Pass systemDefaultRegistry to the Rancher Helm chart (airgap)

### DIFF
--- a/ansible/rke2/airgap/README.md
+++ b/ansible/rke2/airgap/README.md
@@ -186,6 +186,8 @@ rancher_hostname: "rancher.example.com" # Not needed if the inventory file was g
 rancher_bootstrap_password: "your-secure-password"
 rancher_image_tag: v2.12.2
 rancher_use_bundled_system_charts: true
+# Required for airgap: private registry hosting rancher/shell and system images
+rancher_system_default_registry: "privateregistry.example.com:5000"
 ```
 
 **Important Variables:**
@@ -199,6 +201,7 @@ rancher_use_bundled_system_charts: true
 | `rancher_bootstrap_password` | Initial admin password | Required |
 | `rancher_image_tag` | Rancher version to deploy | `v2.12.2` |
 | `rancher_use_bundled_system_charts` | Use bundled charts for airgap | `true` |
+| `rancher_system_default_registry` | Private registry for Rancher system images (airgap); rewrites `shell-image` to `<registry>/rancher/shell:<tag>` at install time | `""` |
 
 #### Run the Deployment
 

--- a/ansible/rke2/airgap/docs/configuration/GROUP_VARS_GUIDE.md
+++ b/ansible/rke2/airgap/docs/configuration/GROUP_VARS_GUIDE.md
@@ -139,6 +139,45 @@ rke2_agent_options: |
 
 See [RKE2 Server Config Reference](https://docs.rke2.io/reference/server_config) and [RKE2 Agent Config Reference](https://docs.rke2.io/reference/linux_agent_config) for all options.
 
+### Rancher Deployment
+
+When `deploy_rancher: true`, Rancher is installed with Helm via the
+[`airgap_rancher_helm_deploy`](../../../../roles/airgap_rancher_helm_deploy/README.md) role.
+
+```yaml
+# inventory/group_vars/all.yml
+deploy_rancher: true
+install_helm: true
+
+rancher_hostname: "rancher.example.com"      # overrides internal_lb_hostname from inventory
+rancher_bootstrap_password: "{{ vault_rancher_bootstrap_password }}"
+rancher_image_tag: v2.12.2
+rancher_use_bundled_system_charts: true
+
+# Airgap: private registry hosting rancher/shell and system images (no scheme)
+rancher_system_default_registry: "harbor.prod.company.com"
+```
+
+Key variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `deploy_rancher` | Enable Rancher deployment | `true` |
+| `install_helm` | Install Helm 3 on the bastion if absent | `true` |
+| `rancher_hostname` | FQDN for the Rancher UI | `internal_lb_hostname` |
+| `rancher_bootstrap_password` | Initial admin password | required |
+| `rancher_image_tag` | Rancher version to deploy | — |
+| `rancher_use_bundled_system_charts` | Use bundled charts (airgap) | `true` |
+| `rancher_system_default_registry` | Airgap registry passed to the chart as `global.cattle.systemDefaultRegistry`; rewrites `shell-image` at install time | `""` |
+
+**Airgap note:** `rancher_system_default_registry` must be set so Rancher rewrites its
+system images (including `shell-image` → `<registry>/rancher/shell:<tag>`) at install time.
+`shell-image` is seeded at Rancher startup and is **not** rewritten when the setting is
+changed later, so it must be configured at deploy time. `rancher/shell:<tag>` must exist
+at `<registry>/rancher/shell:<tag>` (containerd mirrors do not cover this verbatim
+reference). See the [airgap README](../../README.md) (step 6, Deploy Rancher) and the
+[role README](../../../../roles/airgap_rancher_helm_deploy/README.md).
+
 ### Development Configuration
 
 Development environment with relaxed security:

--- a/ansible/rke2/airgap/inventory/group_vars/all.yml.template
+++ b/ansible/rke2/airgap/inventory/group_vars/all.yml.template
@@ -130,6 +130,9 @@ install_helm: true
 rancher_bootstrap_password: "<RANCHER_BOOTSTRAP_PASSWORD>"
 rancher_image_tag: <RANCHER_VERSION>
 rancher_use_bundled_system_charts: true
+# Private registry for all Rancher system images in airgap (no scheme, e.g. host:5000).
+# When set, Rancher rewrites shell-image and system images to <registry>/... at install time.
+rancher_system_default_registry: "<PRIVATE_REGISTRY_URL>"
 
 # rancher_advanced_values:
 #   extraEnv:

--- a/ansible/rke2/airgap/playbooks/deploy/README.md
+++ b/ansible/rke2/airgap/playbooks/deploy/README.md
@@ -33,6 +33,7 @@ ansible-playbook \
 | `rancher_bootstrap_password` | Yes | Bootstrap password set during Helm install |
 | `rancher_admin_password` | Yes | Permanent admin password to set after first login |
 | `rancher_tls_source` | No | TLS source label written to the summary file |
+| `rancher_system_default_registry` | No (airgap: yes) | Private registry passed to the chart as `global.cattle.systemDefaultRegistry`; rewrites `shell-image` at install time. See [role README](../../../../roles/airgap_rancher_helm_deploy/README.md). |
 
 Variables required by the `airgap_rancher_helm_deploy` role are documented in that role's README.
 

--- a/ansible/roles/airgap_rancher_helm_deploy/README.md
+++ b/ansible/roles/airgap_rancher_helm_deploy/README.md
@@ -1,0 +1,100 @@
+# airgap_rancher_helm_deploy Role
+
+Deploys Rancher onto an (airgap) RKE2/K3s cluster using Helm, via a bastion host with
+`kubectl` configured. Installs Helm and cert-manager if needed, installs/upgrades the
+Rancher chart, and waits for the deployment to become ready.
+
+## Requirements
+
+- Bastion host with `kubectl` configured (`kubeconfig_path`)
+- `python3-pip`, `python3-kubernetes`, `python3-yaml` on the bastion
+- The `kubernetes.core` Ansible collection
+- RKE2/K3s cluster already installed and reachable from the bastion
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `install_helm` | `true` | Install Helm 3 on the bastion if not present |
+| `helm_version` | `v3.12.3` | Helm version to install |
+| `kubeconfig_path` | `/home/{{ ansible_user }}/.kube/config` | Kubeconfig used for all Helm/kubectl calls |
+| `rancher_namespace` | `cattle-system` | Namespace Rancher is deployed into |
+| `rancher_helm_chart_repo_url` | `https://releases.rancher.com/server-charts/latest` | Rancher Helm chart repository URL |
+| `rancher_helm_chart_repo_name` | `rancher-latest` | Name to register the chart repository under |
+| `rancher_chart_version` | `""` | Pin a specific chart version (empty = latest) |
+| `rancher_bootstrap_password` | `admin` | Bootstrap password set during Helm install |
+| `rancher_image_tag` | _(unset)_ | Rancher image tag/version to deploy (e.g. `v2.12.2`) |
+| `rancher_private_hostname` / `rancher_hostname` | _(unset)_ | Hostname used in the Rancher ingress/UI |
+| `rancher_use_bundled_system_charts` | `true` | Use bundled system charts (`useBundledSystemChart`) |
+| `rancher_tls_source` | `rancher` | TLS source: `rancher`, `letsEncrypt`, or `secret` |
+| `cert_manager_version` | `""` | cert-manager chart version (SemVer, no `v`); empty = latest |
+| `rancher_system_default_registry` | `""` | **Airgap:** private registry passed to the chart as `global.cattle.systemDefaultRegistry` |
+| `rancher_advanced_values` | `{}` | Extra Helm values merged into the Rancher release |
+
+### `rancher_system_default_registry` (airgap)
+
+Set this to your private registry URL **without a scheme** (e.g.
+`privateregistry.example.com:5000`). When non-empty it is passed to the Rancher Helm
+chart as `global.cattle.systemDefaultRegistry`, so that at **install time** Rancher
+rewrites its system images — including the `shell-image` setting (`rancher/shell:<tag>`,
+used by any Rancher feature that runs a `kubectl`/rancher-shell job) — to
+`<registry>/rancher/shell:<tag>`.
+
+This is **required for airgap**: without it, `shell-image` stays as the public
+`rancher/shell:<tag>` reference and cannot be pulled, which breaks anything that spawns a
+shell job (for example the `WorkloadUpgradeTest` deployment-rollback path in
+`rancher/tests`, failing with a misleading `resource name may not be empty`).
+
+Notes:
+
+- `shell-image` is seeded from `system-default-registry` at **Rancher startup** and is
+  **not** rewritten when the setting is changed post-install, so it must be set at deploy
+  time (which is what this variable does) — patching it after the fact requires a Rancher
+  restart.
+- `rancher/shell:<tag>` must exist at `<registry>/rancher/shell:<tag>`. Containerd registry
+  *mirrors* (e.g. `docker.io` → `proxycache/...`) do not cover this verbatim reference, so
+  the image must be mirrored to the registry root.
+- Leave empty for internet-connected deployments (the chart treats `""` as no registry).
+
+## Example
+
+```yaml
+# group_vars/all.yml
+deploy_rancher: true
+install_helm: true
+
+rancher_hostname: "rancher.example.com"
+rancher_bootstrap_password: "your-secure-password"
+rancher_image_tag: v2.12.2
+rancher_use_bundled_system_charts: true
+
+# Airgap: private registry hosting rancher/shell and system images
+rancher_system_default_registry: "privateregistry.example.com:5000"
+```
+
+```bash
+ansible-playbook -i inventory/inventory.yml \
+  ansible/rke2/airgap/playbooks/deploy/rancher-helm-deploy-playbook.yml
+```
+
+## Helm values applied
+
+The role installs Rancher with (roughly):
+
+```yaml
+hostname: "{{ rancher_private_hostname }}"
+bootstrapPassword: "{{ rancher_bootstrap_password }}"
+useBundledSystemChart: "{{ rancher_use_bundled_system_charts }}"
+rancherImageTag: "{{ rancher_image_tag }}"
+ingress:
+  tls:
+    source: "{{ rancher_tls_source }}"
+global:
+  cattle:
+    systemDefaultRegistry: "{{ rancher_system_default_registry }}"
+```
+
+## Related
+
+- Deploy playbook: [`ansible/rke2/airgap/playbooks/deploy/rancher-helm-deploy-playbook.yml`](../../rke2/airgap/playbooks/deploy/rancher-helm-deploy-playbook.yml)
+- Airgap guide: [`ansible/rke2/airgap/README.md`](../../rke2/airgap/README.md)

--- a/ansible/roles/airgap_rancher_helm_deploy/defaults/main.yml
+++ b/ansible/roles/airgap_rancher_helm_deploy/defaults/main.yml
@@ -23,8 +23,12 @@ rancher_tls_source: "rancher"
 # Cert-manager chart version (SemVer without leading "v", e.g. 1.12.3). Leave empty to use latest.
 cert_manager_version: ""
 
-# Private registry configuration for airgap deployments
-# Set rancher_system_default_registry to your private registry URL (without https://)
+# Private registry configuration for airgap deployments.
+# Set rancher_system_default_registry to your private registry URL (without scheme,
+# e.g. "privateregistry.example.com:5000"). When non-empty it is passed to the Rancher
+# Helm chart as global.cattle.systemDefaultRegistry so that Rancher system images
+# (including the rancher/shell image used by kubectl jobs) resolve to the private
+# registry at install time. Required for airgap; leave empty for internet-connected deploys.
 rancher_system_default_registry: ""
 
 # Optional: Specify custom Rancher image repository

--- a/ansible/roles/airgap_rancher_helm_deploy/tasks/main.yml
+++ b/ansible/roles/airgap_rancher_helm_deploy/tasks/main.yml
@@ -162,6 +162,9 @@
               ingress:
                 tls:
                   source: "{{ rancher_tls_source }}"
+              global:
+                cattle:
+                  systemDefaultRegistry: "{{ rancher_system_default_registry }}"
             verify_ssl: true
       rescue:
         - name: Warn about unsigned Rancher chart
@@ -187,6 +190,9 @@
               ingress:
                 tls:
                   source: "{{ rancher_tls_source }}"
+              global:
+                cattle:
+                  systemDefaultRegistry: "{{ rancher_system_default_registry }}"
 
     - name: Wait for Rancher deployment to be ready
       kubernetes.core.k8s_info:


### PR DESCRIPTION
## Problem
The `airgap_rancher_helm_deploy` role defined `rancher_system_default_registry` in `defaults/main.yml` but **never passed it to the Helm chart** — the variable was a no-op. Rancher deployed with an empty `system-default-registry` setting, so `shell-image` stayed as the public `rancher/shell:<tag>` reference, which is unpullable in an airgap cluster. Any feature that runs a rancher-shell job (e.g. `kubectl.Command`, including deployment rollback in rancher/tests `WorkloadUpgradeTest`) then fails.

## Fix
Add `global.cattle.systemDefaultRegistry: "{{ rancher_system_default_registry }}"` to **both** Helm `values` blocks (signed-chart path and `rescue` fallback). The variable defaults to `""`, so non-airgap callers are unaffected.

```yaml
values:
  hostname: "{{ rancher_private_hostname }}"
  ...
  global:
    cattle:
      systemDefaultRegistry: "{{ rancher_system_default_registry }}"
```

## Verification
- Role YAML parses; `systemDefaultRegistry` referenced in both blocks.
- Live cluster: confirmed `shell-image` is **seeded at Rancher startup** from `system-default-registry` and is **not** rewritten when the setting is changed post-install — so it must be set at deploy time, which is exactly what this change does.
- Before (on a deployed airgap cluster): `system-default-registry=''`, `shell-image='rancher/shell:v0.7.1'`.

## Companion change
`rancher/tests` `Jenkinsfile.airgap-rke2-tests` sets `rancher_system_default_registry: "\${PRIVATE_REGISTRY_URL}"` in the rendered group_vars so this role variable is populated.