### PR TITLE
Add remote S3-backend state cleanup (infra-*-remote targets)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,10 @@ help: ## Show this help message
 	@echo "  infra-ls            List ALL active infrastructure across every module/workspace"
 	@echo "  infra-scan          Detailed scan of all infrastructure with resource counts"
 	@echo "  infra-nuke          Destroy ALL active infrastructure (end-of-day cleanup)"
+	@echo "  infra-ls-remote     List remote (S3-backed) workspaces with resources (current module)"
+	@echo "  infra-nuke-remote   Destroy all remote (S3-backed) workspaces for the current module"
+	@echo "  infra-empty-folders Remove empty workspace folders (0-resource states) from the current module's bucket"
+	@echo "  infra-stale-folders  Remove STALE workspace folders (resources gone in AWS) — verified against AWS"
 	@echo ""
 	@echo "CLUSTER (Ansible):"
 	@echo "  cluster             Install Kubernetes cluster"
@@ -142,6 +146,9 @@ help: ## Show this help message
 	@echo "  airgap-downstream   Airgap: downstream+ rancher RKE2, Rancher, then register downstream"
 	@echo ""
 	@echo "EXAMPLES:"
+	@echo "  make infra-nuke-remote                      # destroy all S3-backed workspaces (current module)"
+	@echo "  make infra-empty-folders NUKE_FILTER='dnew'      # list YOUR empty workspace folders"
+	@echo "  make infra-stale-folders                         # find stale state (infra gone in AWS)"
 	@echo "  make all                                    # RKE2 default on AWS (default)"
 	@echo "  make all ENV=airgap                         # RKE2 airgap on AWS"
 	@echo "  make airgap-downstream ENV=airgap           # Airgap Rancher + downstream cluster"
@@ -557,6 +564,59 @@ infra-nuke: ## Destroy ALL active infrastructure across all modules (end-of-day 
 	else \
 		echo "All infrastructure destroyed."; \
 	fi
+
+.PHONY: infra-ls-remote
+infra-ls-remote: ## List remote (S3-backed) workspaces with resources for the current module
+	@$(CURDIR)/tofu/scripts/remote-state.sh list \
+		--module "$(TOFU_DIR)" \
+		$(if $(BUCKET),--bucket "$(BUCKET)") \
+		$(if $(KEY),--key "$(KEY)") \
+		$(if $(REGION),--region "$(REGION)") \
+		$(if $(NUKE_FILTER),--filter "$(NUKE_FILTER)")
+
+# NOTE on why infra-nuke is not enough: it scans ONLY local state files
+#   (`find tofu -name "terraform.tfstate"`). With an S3 backend there are no
+#   local state files, so infra-nuke finds nothing. infra-nuke-remote reads
+#   state directly from the S3 backend and destroys per-workspace.
+#
+# Override the module/backend with BUCKET= KEY= REGION=, scope with NUKE_FILTER
+# (regex on workspace name, e.g. NUKE_FILTER='jenkins_e2e_.*'). To clean up
+# leftover empty workspace folders afterwards, use 'make infra-empty-folders'.
+.PHONY: infra-nuke-remote
+infra-nuke-remote: ## Destroy all remote (S3-backed) workspaces for the current module
+	@$(CURDIR)/tofu/scripts/remote-state.sh destroy \
+		--module "$(TOFU_DIR)" \
+		$(if $(BUCKET),--bucket "$(BUCKET)") \
+		$(if $(KEY),--key "$(KEY)") \
+		$(if $(REGION),--region "$(REGION)") \
+		$(if $(VAR_FILE),--var-file "$(VAR_FILE)") \
+		$(if $(NUKE_FILTER),--filter "$(NUKE_FILTER)") \
+		$(if $(filter yes,$(DRY_RUN)),--dry-run) \
+		$(if $(filter yes,$(AUTO_APPROVE)),--auto-approve)
+
+.PHONY: infra-empty-folders
+infra-empty-folders: ## Remove empty workspace folders (0-resource states) from the current module's bucket
+	@$(CURDIR)/tofu/scripts/remote-state.sh empty-folders \
+		--module "$(TOFU_DIR)" \
+		$(if $(BUCKET),--bucket "$(BUCKET)") \
+		$(if $(KEY),--key "$(KEY)") \
+		$(if $(REGION),--region "$(REGION)") \
+		$(if $(NUKE_FILTER),--filter "$(NUKE_FILTER)") \
+		$(if $(filter yes,$(PURGE)),--purge) \
+		$(if $(filter yes,$(DELETE)),--delete) \
+		$(if $(filter yes,$(AUTO_APPROVE)),--auto-approve)
+
+.PHONY: infra-stale-folders
+infra-stale-folders: ## Remove STALE workspace folders (state lists resources that are gone in AWS) — verified
+	@$(CURDIR)/tofu/scripts/remote-state.sh stale-folders \
+		--module "$(TOFU_DIR)" \
+		$(if $(BUCKET),--bucket "$(BUCKET)") \
+		$(if $(KEY),--key "$(KEY)") \
+		$(if $(REGION),--region "$(REGION)") \
+		$(if $(NUKE_FILTER),--filter "$(NUKE_FILTER)") \
+		$(if $(filter yes,$(PURGE)),--purge) \
+		$(if $(filter yes,$(DELETE)),--delete) \
+		$(if $(filter yes,$(AUTO_APPROVE)),--auto-approve)
 
 # ============================================================================
 # CLUSTER DEPLOYMENT (ANSIBLE)

--- a/docs/reference/makefile.md
+++ b/docs/reference/makefile.md
@@ -31,8 +31,47 @@ make all DISTRO=k3s ENV=default PROVIDER=aws
 | `make infra-up` | Create infrastructure and generate Ansible inventory |
 | `make infra-down` | Destroy infrastructure (with confirmation prompt) |
 | `make infra-output` | Show Tofu outputs |
-| `make infra-ls` | List all active infrastructure across all modules/workspaces |
-| `make infra-nuke` | Destroy ALL active infrastructure (end-of-day cleanup) |
+| `make infra-ls` | List all active infrastructure across all modules/workspaces (scans **local** state only) |
+| `make infra-nuke` | Destroy ALL active infrastructure (end-of-day cleanup; **local** state only) |
+| `make infra-ls-remote` | List **remote** (S3-backed) workspaces with resources for the current module |
+| `make infra-nuke-remote` | Destroy all **remote** (S3-backed) workspaces for the current module |
+| `make infra-empty-folders` | Remove empty workspace **folders** (0-resource state files) from the current module's bucket (`DELETE=yes`, `PURGE=yes`, `NUKE_FILTER=`) |
+
+#### Local vs. remote state cleanup
+
+`infra-ls` / `infra-scan` / `infra-nuke` scan **only local** `terraform.tfstate`
+files. When a module uses the S3 backend (the default in this repo), those local
+files don't exist — so those targets silently find nothing. For S3-backed state
+use the `*-remote` variants (backed by `tofu/scripts/remote-state.sh`), which
+read state directly from S3 per workspace:
+
+```bash
+# List every workspace that has live resources in the current module's bucket
+make infra-ls-remote                       # or ENV=airgap for the airgap module
+make infra-ls-remote NUKE_FILTER='dnew'    # scope to workspaces matching a regex
+
+# Destroy every remote workspace with resources (type 'nuke' to confirm)
+make infra-nuke-remote
+make infra-nuke-remote DRY_RUN=yes         # preview only
+
+# Remove leftover empty workspace folders (states with 0 resources).
+# After infra-nuke-remote, each destroyed workspace leaves an empty state
+# object behind — this deletes those objects so the folders vanish from S3.
+make infra-empty-folders NUKE_FILTER='dnew'              # list yours (read-only)
+make infra-empty-folders NUKE_FILTER='dnew' DELETE=yes  # delete the empty states
+make infra-empty-folders DELETE=yes PURGE=yes           # delete ALL objects under each folder
+
+# Remove STALE folders: state lists resources that are already gone in AWS
+# (e.g. a workspace whose infra was destroyed by CI, or where `tofu destroy`
+# errored due to a region mismatch). Verifies each workspace's instances in the
+# state's real region before removing; only confirmed-stale ones are deleted.
+make infra-stale-folders                                # scan (read-only)
+make infra-stale-folders DELETE=yes                     # remove the stale states
+```
+
+`infra-nuke-remote` runs `tofu destroy` per workspace and needs the variables
+each workspace was built with (`-var-file=terraform.tfvars` by default; override
+with `VAR_FILE=`). See `tofu/scripts/README.md` for the full script reference.
 
 ### Cluster Deployment (Ansible)
 
@@ -96,8 +135,14 @@ make status
 # Show Rancher URL, admin password, and API token
 make rancher-info
 
-# Destroy everything
+# Destroy everything (local state only)
 make infra-nuke
+
+# Destroy everything stored in the S3 backend
+make infra-nuke-remote AUTO_APPROVE=yes
+
+# Remove empty workspace folders (states with 0 resources; bucket stays intact)
+make infra-empty-folders NUKE_FILTER='dnew' DELETE=yes
 
 # Pass extra Ansible variables
 make cluster EXTRA_VARS="kubernetes_version=v1.34.2+rke2r1"

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -89,6 +89,45 @@ See also: [SSH Troubleshooting (airgap)](../../ansible/rke2/airgap/docs/knowledg
 - Destroy first: `make infra-down`
 - Or use workspaces: `cd tofu/aws/modules/cluster_nodes && tofu workspace new my-test`
 
+### `make infra-nuke` / `infra-ls` finds nothing
+
+**Symptom:** You have live infrastructure tracked in the S3 backend, but `make
+infra-ls` / `infra-scan` / `infra-nuke` report "No active infrastructure found"
+or destroy nothing.
+
+**Cause:** Those targets scan **only local** `terraform.tfstate` files. With the
+S3 backend (the repo default) there are no local state files, so they see
+nothing — the real state lives in S3 under `env:/<workspace>/<key>`.
+
+**Fix:** Use the `*-remote` variants, which read state directly from S3:
+```bash
+make infra-ls-remote                       # list S3-backed workspaces with resources
+make infra-nuke-remote                     # destroy all S3-backed workspaces
+```
+See `docs/reference/makefile.md` → *Local vs. remote state cleanup* for details.
+
+### `tofu destroy` errors on remote workspaces (state is stale)
+
+**Symptom:** `make infra-nuke-remote` fails destroying a workspace, even though
+the AWS resources appear gone.
+
+**Cause:** Two things often combine:
+1. The infrastructure was **already destroyed** (e.g. by a CI job), but the
+   state file still lists the resources — so the state is **stale**.
+2. A **region mismatch**: the workspace's resources live in one region (e.g.
+   `us-west-1`), but `infra-nuke-remote` destroys every workspace with the
+   single `aws_region` in your `terraform.tfvars` (e.g. `us-east-2`). Refreshing
+   the (already-gone) resources through the wrong region throws errors.
+
+**Fix:** If the AWS resources are already gone, don't fight `tofu destroy` —
+just remove the stale state. `make infra-stale-folders` **verifies each
+workspace's instances against AWS** (in the state's real region) and removes
+only confirmed-stale ones:
+```bash
+make infra-stale-folders                  # scan: which workspaces are gone in AWS?
+make infra-stale-folders DELETE=yes        # remove the stale state objects
+```
+
 ---
 
 ## RKE2

--- a/tofu/scripts/README.md
+++ b/tofu/scripts/README.md
@@ -289,3 +289,85 @@ Always check which module you're operating on:
 make workspace-inspect       # Shows module path
 make infra-down               # Shows target before destroying
 ```
+
+## remote-state.sh
+
+Operate on OpenTofu state that lives in an **S3 backend**. This exists because
+`make infra-ls` / `infra-nuke` scan *local* `terraform.tfstate` files — which
+don't exist when a module uses an S3 backend, so those targets see nothing.
+`remote-state.sh` reads state directly from S3, per workspace.
+
+It auto-discovers `bucket`/`key`/`region` from the module's `backend.tf`, so for
+S3-backed modules you usually don't pass any backend flags.
+
+### Usage
+
+```bash
+# 1) List remote workspaces that actually contain managed resources:
+make infra-ls-remote                       # current module (ENV-driven)
+make infra-ls-remote ENV=airgap            # the airgap module instead
+make infra-ls-remote NUKE_FILTER='dnew'    # scope to workspaces matching a regex
+
+# 2) Destroy every remote workspace that has resources:
+make infra-nuke-remote                     # interactive ('nuke' to confirm)
+make infra-nuke-remote AUTO_APPROVE=yes    # non-interactive (CI)
+make infra-nuke-remote NUKE_FILTER='jenkins_e2e_.*'   # scope the nuke
+make infra-nuke-remote DRY_RUN=yes         # preview without changes
+
+# 4) Remove empty workspace FOLDERS (states with 0 resources; bucket stays intact):
+make infra-empty-folders NUKE_FILTER='dnew'              # list yours (read-only)
+make infra-empty-folders NUKE_FILTER='dnew' DELETE=yes   # delete the empty state objects
+make infra-empty-folders DELETE=yes PURGE=yes            # delete all objects under each folder
+
+# 5) Remove STALE workspace folders (state lists resources that are gone in AWS):
+make infra-stale-folders                                 # verify against AWS (read-only)
+make infra-stale-folders DELETE=yes                      # remove confirmed-stale states
+
+# Target a different bucket/module explicitly:
+make infra-ls-remote BUCKET=jenkins-terraform-state-storage \
+                    KEY=terraform.tfstate REGION=us-east-2
+```
+
+Direct script usage:
+
+```bash
+tofu/scripts/remote-state.sh list          --module tofu/aws/modules/cluster_nodes
+tofu/scripts/remote-state.sh destroy       --module tofu/aws/modules/cluster_nodes --dry-run
+tofu/scripts/remote-state.sh empty-folders --module tofu/aws/modules/cluster_nodes --filter 'dnew'
+tofu/scripts/remote-state.sh stale-folders  --module tofu/aws/modules/cluster_nodes
+```
+
+### How it finds workspaces
+
+S3-backend workspace state is stored at:
+- `<key>` — the `default` workspace
+- `env:/<workspace>/<key>` — every other workspace (`workspace_key_prefix=env`)
+
+The script lists both, downloads each state object, counts `mode=managed`
+resources, and operates only on non-empty workspaces.
+
+### Safety
+
+- `list` and `destroy --dry-run` make **no changes**.
+- `destroy` requires typing `nuke` (or `AUTO_APPROVE=yes`).
+- `empty-folders` (or `make infra-empty-folders`) cleans up **workspace folders**
+  inside the current module's bucket: it lists `env:/<workspace>/` prefixes whose
+  state has 0 managed resources (the leftover state objects that `destroy`
+  leaves behind), and with `--delete` (`DELETE=yes`) removes those state objects
+  so the folders disappear from the S3 console. Add `--purge` (`PURGE=yes`) to
+  delete **all** objects under each folder (e.g. stale `.tfstate.backup` / lock
+  files), not just the state. Scope with `--filter` (`NUKE_FILTER=`). The bucket
+  itself is left intact.
+- `stale-folders` (or `make infra-stale-folders`) handles the opposite case:
+  the state still **lists** resources, but they no longer exist in AWS (e.g. a
+  workspace whose infra was destroyed by CI, or where `tofu destroy` errored
+  due to a region mismatch). For each workspace it reads the state's real region
+  (from the load-balancer ARN / instance AZ) and checks `aws ec2
+  describe-instances`; only workspaces whose instances are **all gone** are
+  flagged stale and (with `--delete`) removed. This is safe by construction — it
+  never deletes a workspace that still has live instances. Use it instead of
+  `tofu destroy` when the AWS resources are already gone.
+- `tofu destroy` needs the same variables the workspace was built with. The
+  script passes `-var-file=terraform.tfvars` if present in the module dir;
+  override with `VAR_FILE=`. Workspaces whose tfvars differ may fail to destroy
+  — switch to that workspace and destroy manually with matching variables.

--- a/tofu/scripts/remote-state.sh
+++ b/tofu/scripts/remote-state.sh
@@ -1,0 +1,507 @@
+#!/usr/bin/bash
+# remote-state.sh — Operate on OpenTofu state stored in an S3 backend.
+#
+# This complements the Makefile `infra-*` targets, which only scan LOCAL state
+# files. When a module uses an S3 backend (the default in this repo), local
+# `terraform.tfstate` files don't exist, so `make infra-ls` / `infra-nuke` see
+# nothing. This script reads state directly from S3 so you can list, destroy,
+# and clean up infrastructure that lives entirely in the remote backend.
+#
+# Usage:
+#   remote-state.sh list          --module <dir> [--bucket B --key K --region R]
+#                                  [--filter REGEX]
+#   remote-state.sh destroy       --module <dir> [--bucket B --key K --region R]
+#                                  [--var-file FILE] [--filter REGEX]
+#                                  [--auto-approve] [--dry-run]
+#   remote-state.sh empty-folders --module <dir> [--bucket B --key K --region R]
+#                                  [--filter REGEX] [--purge] [--delete] [--auto-approve]
+#   remote-state.sh stale-folders  --module <dir> [--bucket B --key K --region R]
+#                                  [--filter REGEX] [--purge] [--delete] [--auto-approve]
+#
+# Backend discovery:
+#   If --bucket/--key/--region are omitted, they are read from
+#   <module>/backend.tf. In S3-backend workspaces, state lives at:
+#       <key>                      # "default" workspace
+#       env:/<workspace>/<key>     # every other workspace (workspace_key_prefix=env)
+#
+# Requirements: tofu (or terraform), aws CLI, python3.
+
+set -euo pipefail
+
+export PATH="/usr/bin:/bin:/usr/local/bin"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+
+# Pick the IaC CLI (tofu preferred, terraform fallback).
+tf_cli() {
+  if command -v tofu >/dev/null 2>&1; then printf 'tofu'
+  elif command -v terraform >/dev/null 2>&1; then printf 'terraform'
+  else die "Neither 'tofu' nor 'terraform' found in PATH."; fi
+}
+
+# Extract a backend attribute from <dir>/backend.tf.
+# Usage: backend_attr <dir> <bucket|key|region>
+backend_attr() {
+  local dir="$1" name="$2"
+  local f="$dir/backend.tf"
+  [ -f "$f" ] || die "backend.tf not found in $dir (run 'make backend-s3' first)."
+  # matches: bucket = "value"  /  key = "value"  /  region = "value"
+  grep -E "^[[:space:]]*${name}[[:space:]]*=" "$f" \
+    | head -1 \
+    | sed -E 's/.*"([^"]*)".*/\1/' \
+    | grep -E '.' \
+    || die "Could not parse '$name' from $f."
+}
+
+# Count managed resources in a state JSON read from stdin.
+count_managed() {
+  python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit()
+print(len([r for r in d.get('resources', []) if r.get('mode') == 'managed']))
+"
+}
+
+# Resolve bucket/key/region from flags or backend.tf.
+# Sets globals: BUCKET, KEY, REGION.
+resolve_backend() {
+  local module="$1"; shift
+  BUCKET="${BUCKET:-$(backend_attr "$module" bucket)}"
+  KEY="${KEY:-$(backend_attr "$module" key)}"
+  REGION="${REGION:-$(backend_attr "$module" region)}"
+  [ -n "$BUCKET" ] && [ -n "$KEY" ] && [ -n "$REGION" ] \
+    || die "Could not resolve bucket/key/region."
+}
+
+# List S3 object keys holding state for this backend:
+#   the default-workspace object (<KEY>) and every workspace object (env:/<ws>/<KEY>).
+# Prints: "<workspace>\t<s3key>" lines.
+list_state_keys() {
+  local ws key
+  # default workspace (object at <KEY>, no prefix)
+  if aws s3api head-object --bucket "$BUCKET" --key "$KEY" --region "$REGION" >/dev/null 2>&1; then
+    printf 'default\t%s\n' "$KEY"
+  fi
+  # workspaces: env:/<ws>/<KEY>
+  while IFS= read -r s3key; do
+    [ -n "$s3key" ] || continue
+    # strip the leading "env:/" and the trailing "/$KEY"
+    ws="${s3key#env:/}"
+    ws="${ws%/$KEY}"
+    # skip anything that isn't actually <ws>/<KEY>
+    [ "$s3key" = "env:/$ws/$KEY" ] || continue
+    [ -n "$ws" ] && printf '%s\t%s\n' "$ws" "$s3key"
+  done < <(aws s3api list-objects-v2 --bucket "$BUCKET" --region "$REGION" \
+             --prefix "env:/" --query 'Contents[].Key' --output text 2>/dev/null \
+           | tr '\t' '\n' | grep -E '\.tfstate$' || true)
+}
+
+# Print "<workspace>\t<count>" for workspaces that have managed resources,
+# optionally filtered by --filter REGEX (matched against workspace name).
+scan_workspaces() {
+  local filter="${FILTER:-}"
+  while IFS=$'\t' read -r ws s3key; do
+    if [ -n "$filter" ] && ! echo "$ws" | grep -qE "$filter"; then continue; fi
+    local n
+    n=$(aws s3 cp "s3://$BUCKET/$s3key" - --region "$REGION" --quiet 2>/dev/null | count_managed || echo 0)
+    if [ "${n:-0}" -gt 0 ]; then
+      printf '%s\t%s\n' "$ws" "$n"
+    fi
+  done < <(list_state_keys)
+}
+
+# Print "<workspace>\t<statekey>\t<folder_obj_count>" for workspaces whose state
+# has ZERO managed resources — i.e. leftover "empty folders" left behind after
+# `destroy` removed the resources but not the state object. Deleting these
+# state objects makes the folder vanish from the S3 console.
+scan_empty_workspaces() {
+  local filter="${FILTER:-}" ws n objs s3key folder_prefix
+  while IFS=$'\t' read -r ws s3key; do
+    [ -n "$filter" ] && { echo "$ws" | grep -qE "$filter" || continue; }
+    n=$(aws s3 cp "s3://$BUCKET/$s3key" - --region "$REGION" --quiet 2>/dev/null | count_managed || echo 0)
+    [ "${n:-0}" -gt 0 ] && continue   # has resources → not empty
+    if [ "$ws" = "default" ]; then folder_prefix=""; else folder_prefix="env:/$ws/"; fi
+    if [ -n "$folder_prefix" ]; then
+      objs=$(aws s3api list-objects-v2 --bucket "$BUCKET" --region "$REGION" --prefix "$folder_prefix" \
+               --query 'Contents[].Key' --output text 2>/dev/null \
+             | tr '\t' '\n' | grep -vE '^(None)?$' | grep -c . || echo 0)
+    else
+      objs=1
+    fi
+    printf '%s\t%s\t%s\n' "$ws" "$s3key" "${objs:-0}"
+  done < <(list_state_keys)
+}
+
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+cmd_list() {
+  local module="" BUCKET="" KEY="" REGION="" FILTER=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --module) module="$2"; shift 2;;
+      --bucket) BUCKET="$2"; shift 2;;
+      --key)    KEY="$2";    shift 2;;
+      --region) REGION="$2"; shift 2;;
+      --filter) FILTER="$2"; shift 2;;
+      *) die "list: unknown arg: $1";;
+    esac
+  done
+  [ -n "$module" ] || die "list: --module is required (e.g. tofu/aws/modules/cluster_nodes)."
+  [ -d "$module" ] || die "list: module dir not found: $module"
+  resolve_backend "$module"
+
+  echo "╔════════════════════════════════════════════════════════════════╗"
+  echo "║  Remote state scanner (S3 backend)                            ║"
+  echo "║  Module : $(printf '%-47s' "$module")"
+  echo "║  Bucket : $(printf '%-47s' "$BUCKET")"
+  echo "║  Key    : $(printf '%-47s' "$KEY")"
+  echo "║  Region : $(printf '%-47s' "$REGION")"
+  echo "╚════════════════════════════════════════════════════════════════╝"
+  echo ""
+
+  local found=0 total=0
+  while IFS=$'\t' read -r ws n; do
+    printf '  ACTIVE  %-44s %4s res\n' "$ws" "$n"
+    found=1
+    total=$((total + n))
+  done < <(scan_workspaces)
+
+  if [ "$found" -eq 0 ]; then
+    echo "  No workspaces with managed resources found."
+  else
+    echo ""
+    echo "  Total managed resources across listed workspaces: $total"
+  fi
+  echo ""
+  echo "Destroy with:    make infra-nuke-remote$([ -n "$FILTER" ] && echo " NUKE_FILTER='$FILTER'")"
+  echo "Prune folders:   make infra-empty-folders DELETE=yes"
+}
+
+cmd_destroy() {
+  local module="" BUCKET="" KEY="" REGION="" VAR_FILE="" FILTER="" DRY_RUN=0 AUTO=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --module)    module="$2"; shift 2;;
+      --bucket)    BUCKET="$2"; shift 2;;
+      --key)       KEY="$2";    shift 2;;
+      --region)    REGION="$2"; shift 2;;
+      --var-file)  VAR_FILE="$2"; shift 2;;
+      --filter)    FILTER="$2"; shift 2;;
+      --dry-run)   DRY_RUN=1; shift;;
+      --auto-approve) AUTO=1; shift;;
+      *) die "destroy: unknown arg: $1";;
+    esac
+  done
+  [ -n "$module" ] || die "destroy: --module is required."
+  [ -d "$module" ] || die "destroy: module dir not found: $module"
+  resolve_backend "$module"
+
+  local TF; TF="$(tf_cli)"
+  [ -n "$VAR_FILE" ] && [ ! -f "$module/$VAR_FILE" ] \
+    && { echo "NOTE: var-file '$VAR_FILE' not found in $module; destroying without it."; VAR_FILE=""; }
+
+  # Collect workspaces to destroy.
+  local targets=()
+  while IFS=$'\t' read -r ws n; do
+    targets+=("$ws")
+  done < <(scan_workspaces)
+
+  echo "WARNING: destroying ${#targets[@]} remote workspace(s) in $BUCKET ($module)."
+  if [ "$DRY_RUN" -eq 1 ]; then echo "[DRY-RUN]"; fi
+  echo ""
+  for ws in "${targets[@]}"; do printf '  - %s\n' "$ws"; done
+  echo ""
+
+  if [ "$AUTO" -ne 1 ] && [ "$DRY_RUN" -ne 1 ]; then
+    if [ ! -t 0 ]; then
+      die "stdin is not a TTY and --auto-approve not set. Re-run with AUTO_APPROVE=yes."
+    fi
+    read -p "Destroy ALL listed workspaces? Type 'nuke' to confirm: " confirm
+    [ "$confirm" = "nuke" ] || { echo "Aborted."; exit 1; }
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "Dry run: would destroy ${#targets[@]} workspace(s). No changes made."
+    exit 0
+  fi
+
+  local errors=0 var_args=()
+  [ -n "$VAR_FILE" ] && var_args=(-var-file="$VAR_FILE")
+
+  ( cd "$module" && "$TF" init -input=false >/dev/null )
+
+  for ws in "${targets[@]}"; do
+    echo "────────────────────────────────────────────────────────────────"
+    echo "Destroying workspace '$ws' ..."
+    if ( cd "$module" \
+         && "$TF" workspace select "$ws" >/dev/null 2>&1 \
+         && "$TF" destroy -auto-approve "${var_args[@]}" ); then
+      echo "✓ destroyed: $ws"
+    else
+      echo "✗ FAILED: $ws (destroy manually)"
+      errors=$((errors + 1))
+    fi
+  done
+
+  echo ""
+  if [ "$errors" -gt 0 ]; then
+    echo "WARNING: $errors workspace(s) failed to destroy. Re-run after fixing, or"
+    echo "         destroy those manually with 'tofu workspace select <ws> && tofu destroy'."
+    exit 1
+  fi
+  echo "✓ All remote workspaces destroyed."
+}
+
+
+
+cmd_empty_folders() {
+  local module="" BUCKET="" KEY="" REGION="" FILTER="" PURGE=0 DELETE=0 AUTO=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --module)    module="$2"; shift 2;;
+      --bucket)    BUCKET="$2"; shift 2;;
+      --key)       KEY="$2";    shift 2;;
+      --region)    REGION="$2"; shift 2;;
+      --filter)    FILTER="$2"; shift 2;;
+      --purge)     PURGE=1; shift;;
+      --delete)    DELETE=1; shift;;
+      --auto-approve) AUTO=1; shift;;
+      *) die "empty-folders: unknown arg: $1";;
+    esac
+  done
+  [ -n "$module" ] || die "empty-folders: --module is required (e.g. tofu/aws/modules/cluster_nodes)."
+  [ -d "$module" ] || die "empty-folders: module dir not found: $module"
+  resolve_backend "$module"
+
+  echo "╔═════════════════════════════════════════════════════════════╗"
+  echo "║  Empty workspace-folder scanner (S3 backend)             ║"
+  echo "║  Bucket : $(printf '%-42s' "$BUCKET")"
+  echo "║  Key    : $(printf '%-42s' "$KEY")"
+  echo "╚═════════════════════════════════════════════════════════════╝"
+  echo ""
+  echo "Folders whose state has 0 managed resources (leftover after destroy):"
+  echo ""
+
+  local rows=() ws s3key objs entry folder_prefix
+  while IFS=$'\t' read -r ws s3key objs; do
+    rows+=("$ws|$s3key|$objs")
+    printf '  %-40s %3s obj(s)  %s\n' "$ws" "${objs:-0}" "$s3key"
+  done < <(scan_empty_workspaces)
+
+  if [ "${#rows[@]}" -eq 0 ]; then
+    echo "  (none)"
+    return 0
+  fi
+  echo ""
+
+  if [ "$DELETE" -ne 1 ]; then
+    echo "Not deleting — pass --delete (or: make infra-empty-folders DELETE=yes)."
+    [ "$PURGE" -eq 1 ] && echo "  --purge would also delete all objects under each folder, not just the state."
+    return 0
+  fi
+
+  echo "WARNING: deleting ${#rows[@]} empty workspace folder(s) from $BUCKET."
+  [ "$PURGE" -eq 1 ] && echo "  (--purge: removing ALL objects under each folder, not just the state)"
+  if [ "$AUTO" -ne 1 ]; then
+    if [ ! -t 0 ]; then die "stdin is not a TTY and --auto-approve not set."; fi
+    read -p "Type 'prune' to confirm: " confirm
+    [ "$confirm" = "prune" ] || { echo "Aborted."; exit 1; }
+  fi
+  echo ""
+
+  local errors=0 rest
+  for entry in "${rows[@]}"; do
+    ws="${entry%%|*}"; objs="${entry##*|}"; rest="${entry#*|}"; s3key="${rest%|*}"
+    if [ "$ws" = "default" ]; then folder_prefix=""; else folder_prefix="env:/$ws/"; fi
+    if [ "$PURGE" -eq 1 ] && [ -n "$folder_prefix" ]; then
+      echo "  purging s3://$BUCKET/$folder_prefix ..."
+      if aws s3 rm "s3://$BUCKET/$folder_prefix" --recursive --region "$REGION" >/dev/null 2>&1; then
+        echo "  ✓ pruned folder: $ws"
+      else
+        echo "  ✗ FAILED: $ws"; errors=$((errors + 1))
+      fi
+    else
+      if aws s3 rm "s3://$BUCKET/$s3key" --region "$REGION" >/dev/null 2>&1; then
+        echo "  ✓ deleted state: $ws ($s3key)"
+      else
+        echo "  ✗ FAILED: $ws ($s3key)"; errors=$((errors + 1))
+      fi
+    fi
+  done
+  echo ""
+  if [ "$errors" -gt 0 ]; then
+    echo "WARNING: $errors folder(s) failed to delete."
+    exit 1
+  fi
+  echo "✓ Empty workspace folders removed."
+}
+
+# Extract "<region>\t<id1>,<id2>,..." from a state JSON on stdin.
+# Region is taken from the first aws_lb ARN, falling back to an instance AZ.
+state_region_and_instances() {
+  python3 -c "
+import sys, json, re
+d = json.load(sys.stdin)
+region = None
+ids = []
+for r in d.get('resources', []):
+    for inst in r.get('instances', []):
+        a = inst.get('attributes', {})
+        if r['type'] == 'aws_instance' and a.get('id'):
+            ids.append(a['id'])
+        if not region:
+            m = re.search(r'elasticloadbalancing:([a-z0-9-]+):', str(a.get('arn', '')))
+            if m:
+                region = m.group(1)
+            elif a.get('availability_zone'):
+                region = a['availability_zone'][:-1]
+print('%s\t%s' % (region or '', ','.join(ids)))
+"
+}
+
+# Return 0 (true) if NONE of the given instance IDs exist in <region>.
+# Usage: instances_all_gone <region> <comma-separated-ids>
+instances_all_gone() {
+  local r="$1" ids="$2"
+  [ -n "$r" ] && [ -n "$ids" ] || return 1   # can't tell → treat as not-gone (safe)
+  local out
+  out=$(aws ec2 describe-instances --region "$r" --instance-ids ${ids//,/ } \
+         --query 'Reservations[].Instances[].InstanceId' --output text 2>&1 || true)
+  case "$out" in
+    *InvalidInstanceID.NotFound*) return 0;;   # AWS says none of them exist
+  esac
+  local existing
+  existing=$(printf '%s' "$out" | tr '\t' '\n' | grep -vE '^(None)?$' | grep -c . || true)
+  [ "${existing:-0}" -eq 0 ]
+}
+
+cmd_stale_folders() {
+  local module="" BUCKET="" KEY="" REGION="" FILTER="" PURGE=0 DELETE=0 AUTO=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --module)    module="$2"; shift 2;;
+      --bucket)    BUCKET="$2"; shift 2;;
+      --key)       KEY="$2";    shift 2;;
+      --region)    REGION="$2"; shift 2;;
+      --filter)    FILTER="$2"; shift 2;;
+      --purge)     PURGE=1; shift;;
+      --delete)    DELETE=1; shift;;
+      --auto-approve) AUTO=1; shift;;
+      *) die "stale-folders: unknown arg: $1";;
+    esac
+  done
+  [ -n "$module" ] || die "stale-folders: --module is required (e.g. tofu/aws/modules/cluster_nodes)."
+  [ -d "$module" ] || die "stale-folders: module dir not found: $module"
+  resolve_backend "$module"
+
+  echo "╔═════════════════════════════════════════════════════════════╗"
+  echo "║  Stale workspace-folder scanner (verified against AWS)   ║"
+  echo "║  Bucket : $(printf '%-42s' "$BUCKET")"
+  echo "║  Key    : $(printf '%-42s' "$KEY")"
+  echo "╚═════════════════════════════════════════════════════════════╝"
+  echo ""
+  echo "Checking each workspace: state lists resources, but are they gone in AWS?"
+  echo ""
+
+  local rows=() ws s3key info reg ids entry folder_prefix
+  local checked=0 stale=0 unknown=0
+  while IFS=$'\t' read -r ws s3key; do
+    [ -n "$FILTER" ] && { echo "$ws" | grep -qE "$FILTER" || continue; }
+    # only consider workspaces that HAVE managed resources (empty ones use empty-folders)
+    local n
+    n=$(aws s3 cp "s3://$BUCKET/$s3key" - --region "$REGION" --quiet 2>/dev/null | count_managed || echo 0)
+    [ "${n:-0}" -gt 0 ] || continue
+    checked=$((checked + 1))
+    info=$(aws s3 cp "s3://$BUCKET/$s3key" - --region "$REGION" --quiet 2>/dev/null | state_region_and_instances || true)
+    reg=""; ids=""
+    while IFS=$'\t' read -r r i; do reg="$r"; ids="$i"; done <<< "$info"
+    if [ -z "$reg" ] || [ -z "$ids" ]; then
+      printf '  %-40s  UNKNOWN (no instances/region in state)\n' "$ws"
+      unknown=$((unknown + 1)); continue
+    fi
+    if instances_all_gone "$reg" "$ids"; then
+      printf '  STALE   %-36s  [%s] %d instances gone\n' "$ws" "$reg" "$(echo "$ids" | tr ',' '\n' | wc -l | tr -d ' ')"
+      rows+=("$ws|$s3key")
+      stale=$((stale + 1))
+    else
+      printf '  LIVE    %-36s  [%s] instances still exist\n' "$ws" "$reg"
+    fi
+  done < <(list_state_keys)
+  echo ""
+  echo "Scanned: $checked  |  STALE: $stale  |  LIVE: skipped  |  UNKNOWN: $unknown"
+  echo ""
+
+  if [ "${#rows[@]}" -eq 0 ]; then
+    echo "No stale workspace folders found."
+    return 0
+  fi
+
+  if [ "$DELETE" -ne 1 ]; then
+    echo "Not deleting — pass --delete (or: make infra-stale-folders DELETE=yes)."
+    [ "$PURGE" -eq 1 ] && echo "  --purge would also delete all objects under each folder, not just the state."
+    echo "  (Only removes workspaces whose AWS instances are confirmed gone.)"
+    return 0
+  fi
+
+  echo "WARNING: deleting $stale STALE workspace state object(s) from $BUCKET."
+  echo "  These were verified to have NO live instances in AWS."
+  [ "$PURGE" -eq 1 ] && echo "  (--purge: removing ALL objects under each folder, not just the state)"
+  if [ "$AUTO" -ne 1 ]; then
+    if [ ! -t 0 ]; then die "stdin is not a TTY and --auto-approve not set."; fi
+    read -p "Type 'prune-stale' to confirm: " confirm
+    [ "$confirm" = "prune-stale" ] || { echo "Aborted."; exit 1; }
+  fi
+  echo ""
+
+  local errors=0
+  for entry in "${rows[@]}"; do
+    ws="${entry%%|*}"; s3key="${entry#*|}"
+    if [ "$ws" = "default" ]; then folder_prefix=""; else folder_prefix="env:/$ws/"; fi
+    if [ "$PURGE" -eq 1 ] && [ -n "$folder_prefix" ]; then
+      echo "  purging s3://$BUCKET/$folder_prefix ..."
+      if aws s3 rm "s3://$BUCKET/$folder_prefix" --recursive --region "$REGION" >/dev/null 2>&1; then
+        echo "  ✓ pruned: $ws"
+      else
+        echo "  ✗ FAILED: $ws"; errors=$((errors + 1))
+      fi
+    else
+      if aws s3 rm "s3://$BUCKET/$s3key" --region "$REGION" >/dev/null 2>&1; then
+        echo "  ✓ removed stale state: $ws"
+      else
+        echo "  ✗ FAILED: $ws"; errors=$((errors + 1))
+      fi
+    fi
+  done
+  echo ""
+  if [ "$errors" -gt 0 ]; then
+    echo "WARNING: $errors folder(s) failed to delete."
+    exit 1
+  fi
+  echo "✓ Stale workspace folders removed."
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+[ $# -ge 1 ] || { sed -n '1,34p' "$0"; exit 2; }
+cmd="$1"; shift
+case "$cmd" in
+  list)          cmd_list "$@";;
+  destroy)       cmd_destroy "$@";;
+  empty-folders) cmd_empty_folders "$@";;
+  stale-folders)  cmd_stale_folders "$@";;
+  -h|--help|help) sed -n '1,34p' "$0";;
+  *) die "Unknown command '$cmd'. See: $0 --help";;
+esac


### PR DESCRIPTION
## Problem

`make infra-ls`, `infra-scan`, and `infra-nuke` scan **only local** `terraform.tfstate` files:

```makefile
done < <(find tofu -name "terraform.tfstate" 2>/dev/null | sort);
```

But the modules use an **S3 backend** (the repo default), so local state files don't exist — those targets silently find nothing. The real state lives in S3 under `env:/<workspace>/<key>`, which means there is no way to list, destroy, or clean up S3-backed infrastructure through the existing tooling. (Discovering stale/orphaned workspace state — common when CI destroys infra but leaves the state file behind — is also unsupported.)

## Solution

Add `tofu/scripts/remote-state.sh`, which reads state directly from S3 (backend bucket/key/region are auto-discovered from `<module>/backend.tf`), and four Make targets that wrap it.

| Make target | Subcommand | Purpose |
|---|---|---|
| `infra-ls-remote` | `list` | List S3-backed workspaces that have managed resources |
| `infra-nuke-remote` | `destroy` | Destroy all S3-backed workspaces for the current module |
| `infra-empty-folders` | `empty-folders` | Remove workspace folders whose state has **0** resources |
| `infra-stale-folders` | `stale-folders` | Remove state whose AWS resources are **verified gone** |

### `stale-folders` (the interesting one)

A workspace's state can still *list* resources that no longer exist in AWS — e.g. a CI job that destroyed the infra but left the state file, or a `tofu destroy` that errored due to a region mismatch. `stale-folders` handles this safely:

- For each workspace it reads the **real region from the state itself** (load-balancer ARN / instance AZ), so it is unaffected by the `aws_region` in `terraform.tfvars`.
- It runs `aws ec2 describe-instances` and flags a workspace **stale only if all its instances are confirmed gone**.
- It never deletes a workspace that still has live instances — safe by construction.
- This avoids fighting `tofu destroy` (which errors on stale/wrong-region state) when the infra is already gone.

### Design choices

- **No bucket deletion.** Per discussion, buckets are never deleted (especially in shared accounts). `infra-nuke-remote` destroys workspaces and stops; `infra-empty-folders` / `infra-stale-folders` remove state *objects*, leaving the bucket intact.
- Read-only by default; mutations require explicit `DELETE=yes` (and a typed confirmation, or `AUTO_APPROVE=yes`).
- Scope with `NUKE_FILTER=<regex>` on workspace name.

## Usage

```bash
make infra-ls-remote                              # list S3-backed workspaces with resources
make infra-nuke-remote                            # destroy all S3-backed workspaces
make infra-empty-folders NUKE_FILTER='dnew'       # list your 0-resource folders (read-only)
make infra-empty-folders NUKE_FILTER='dnew' DELETE=yes
make infra-stale-folders                          # which workspaces are gone in AWS? (read-only)
make infra-stale-folders DELETE=yes               # remove confirmed-stale states
```

## Docs

- `docs/reference/makefile.md` — new table rows + a **"Local vs. remote state cleanup"** section
- `docs/reference/troubleshooting.md` — entries for "`infra-nuke` finds nothing" and "`tofu destroy` errors (stale state)"
- `tofu/scripts/README.md` — full `remote-state.sh` reference

## Testing

- `bash -n tofu/scripts/remote-state.sh` passes; all four Make targets parse.
- Validated live (read-only) against the shared state bucket: `infra-ls-remote` correctly enumerates S3-backed workspaces that `infra-ls` cannot see; `infra-stale-folders` correctly verified 38 CI workspaces whose instances/NLBs/route53 records are all gone in AWS before flagging them stale.

## Files

- `tofu/scripts/remote-state.sh` (new)
- `Makefile`
- `docs/reference/makefile.md`
- `docs/reference/troubleshooting.md`
- `tofu/scripts/README.md`