### PR TITLE
Skip standalone traefik tarball for RKE2 v1.36+ in airgap deploys

### DIFF
--- a/ansible/rke2/airgap/README.md
+++ b/ansible/rke2/airgap/README.md
@@ -72,6 +72,14 @@ This system uses the **Tarball Method** for pure airgap deployments:
 - **Features**: Uses pre-downloaded RKE2 tarballs with embedded images (no registry required)
 - **Status**: [OK] **Currently Working and Tested**
 
+> **Note (RKE2 v1.36+):** As of v1.36, RKE2 no longer publishes a standalone
+> `rke2-images-traefik` tarball — the Traefik ingress images are now bundled
+> inside `rke2-images-core.tar.gz` (Traefik is the default ingress because
+> upstream `ingress-nginx` was retired). This is handled automatically: the
+> roles detect `rke2_version` and skip the standalone traefik tarball for
+> v1.36+, so **no private-registry mirror of Traefik is required**. Override
+> with the `rke2_traefik_tarball` variable (see Global Variables) if needed.
+
 ## Quick Start
 
 ### 1. Configure Inventory
@@ -359,6 +367,12 @@ Key configuration options:
 ```yaml
 # RKE2 Configuration
 rke2_version: "v1.31.11+rke2r1"
+
+# Standalone traefik image tarball handling (airgap tarball method):
+#   "auto" -> skip on RKE2 v1.36+ (Traefik images ship inside rke2-images-core)
+#   true    -> always include the standalone rke2-images-traefik tarball (<= v1.35)
+#   false   -> never include it
+rke2_traefik_tarball: "auto"
 
 # Server configuration options (applied to server/control-plane nodes)
 # These are appended to /etc/rancher/rke2/config.yaml after core settings

--- a/ansible/roles/airgap_rke2_bundle_manager/defaults/main.yml
+++ b/ansible/roles/airgap_rke2_bundle_manager/defaults/main.yml
@@ -30,3 +30,10 @@ rke2_regenerate_checksums_on_failure: true
 
 # Cleanup temporary files after bundle creation
 rke2_cleanup_temp_files: true
+
+# Standalone traefik image tarball handling.
+#   "auto"  -> auto-detect from rke2_version (bundled into rke2-images-core on v1.36+,
+#              so the standalone rke2-images-traefik.* asset is skipped for >= 1.36)
+#   true     -> always include the standalone traefik tarball (<= v1.35 / custom build)
+#   false    -> never include it
+rke2_traefik_tarball: "auto"

--- a/ansible/roles/airgap_rke2_bundle_manager/tasks/create_bundle.yml
+++ b/ansible/roles/airgap_rke2_bundle_manager/tasks/create_bundle.yml
@@ -33,10 +33,16 @@
       dest: "{{ rke2_staging_dir }}/tmp/rke2-artifacts/rke2-images-core.tar.gz"
     - src: "{{ rke2_temp_dir }}/rke2-images-cni.tar.gz"
       dest: "{{ rke2_staging_dir }}/tmp/rke2-artifacts/rke2-images-cni.tar.gz"
-    - src: "{{ rke2_temp_dir }}/rke2-images-traefik.tar.gz"
-      dest: "{{ rke2_staging_dir }}/tmp/rke2-artifacts/rke2-images-traefik.tar.gz"
     - src: "{{ rke2_temp_dir }}/sha256sum-{{ rke2_arch }}.txt"
       dest: "{{ rke2_staging_dir }}/tmp/rke2-artifacts/sha256sum-{{ rke2_arch }}.txt"
+
+- name: Copy Traefik images to staging directory
+  ansible.builtin.copy:
+    src: "{{ rke2_temp_dir }}/rke2-images-traefik.tar.gz"
+    dest: "{{ rke2_staging_dir }}/tmp/rke2-artifacts/rke2-images-traefik.tar.gz"
+    mode: preserve
+    remote_src: true
+  when: rke2_traefik_tarball_enabled | bool
 
 - name: Create archive of RKE2 files
   community.general.archive:

--- a/ansible/roles/airgap_rke2_bundle_manager/tasks/download_artifacts.yml
+++ b/ansible/roles/airgap_rke2_bundle_manager/tasks/download_artifacts.yml
@@ -26,6 +26,22 @@
   ansible.builtin.set_fact:
     rke2_arch: "{{ ansible_facts.architecture | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }}"
 
+- name: Detect whether standalone traefik tarball is shipped by this RKE2 release
+  ansible.builtin.set_fact:
+    rke2_traefik_tarball_enabled: >-
+      {{
+        (rke2_traefik_tarball == 'auto') | ternary(
+          (((rke2_version | regex_replace('^v', '')).split('+')[0]) is version('1.36.0', '<')),
+          (rke2_traefik_tarball | bool)
+        )
+      }}
+
+- name: Show traefik tarball decision
+  ansible.builtin.debug:
+    msg: >-
+      Standalone traefik tarball for RKE2 {{ rke2_version }}:
+      {{ 'INCLUDED' if (rke2_traefik_tarball_enabled | bool) else 'SKIPPED (Traefik images are bundled in rke2-images-core on v1.36+)' }}
+
 - name: Show urls used to get artifacts
   ansible.builtin.debug:
     msg: |
@@ -82,6 +98,7 @@
   retries: "{{ rke2_download_retries }}"
   delay: "{{ rke2_download_delay }}"
   become: false
+  when: rke2_traefik_tarball_enabled | bool
 
 - name: Download checksum file
   ansible.builtin.get_url:

--- a/ansible/roles/airgap_rke2_bundle_manager/tasks/verify_checksums.yml
+++ b/ansible/roles/airgap_rke2_bundle_manager/tasks/verify_checksums.yml
@@ -81,6 +81,7 @@
   failed_when: false
   args:
     executable: /bin/bash
+  when: rke2_traefik_tarball_enabled | bool
 
 - name: Display checksum verification results
   ansible.builtin.debug:
@@ -89,14 +90,14 @@
       - RKE2 Tarball: {{ tarball_checksum_verify.stdout }}
       - Core Images: {{ core_images_checksum_verify.stdout }}
       - CNI Images: {{ cni_images_checksum_verify.stdout }}
-      - Traefik Images: {{ traefik_images_checksum_verify.stdout }}
+      - Traefik Images: {{ traefik_images_checksum_verify.stdout | default('SKIPPED') }}
 
 - name: Handle checksum verification failure
   when: >-
     tarball_checksum_verify.rc != 0 or
     core_images_checksum_verify.rc != 0 or
     cni_images_checksum_verify.rc != 0 or
-    traefik_images_checksum_verify.rc != 0
+    (rke2_traefik_tarball_enabled | bool and (traefik_images_checksum_verify.rc | default(0)) != 0)
   block:
     - name: Fail on checksum mismatch
       ansible.builtin.fail:
@@ -105,7 +106,7 @@
           RKE2 Tarball: {{ tarball_checksum_verify.stdout }}
           Core Images: {{ core_images_checksum_verify.stdout }}
           CNI Images: {{ cni_images_checksum_verify.stdout }}
-          Traefik Images: {{ traefik_images_checksum_verify.stdout }}
+          Traefik Images: {{ traefik_images_checksum_verify.stdout | default('SKIPPED') }}
 
 - name: Confirm successful verification
   ansible.builtin.debug:
@@ -114,4 +115,4 @@
     tarball_checksum_verify.rc == 0 and
     core_images_checksum_verify.rc == 0 and
     cni_images_checksum_verify.rc == 0 and
-    traefik_images_checksum_verify.rc == 0
+    (not (rke2_traefik_tarball_enabled | bool) or (traefik_images_checksum_verify.rc | default(0)) == 0)

--- a/ansible/roles/airgap_rke2_install/defaults/main.yml
+++ b/ansible/roles/airgap_rke2_install/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Default variables for airgap_rke2_install role
+
+# Standalone traefik image tarball handling.
+#   "auto"  -> auto-detect from rke2_version (bundled into rke2-images-core on v1.36+,
+#              so the standalone rke2-images-traefik.* asset is skipped for >= 1.36)
+#   true     -> always expect the standalone traefik tarball (<= v1.35 / custom build)
+#   false    -> never expect it
+rke2_traefik_tarball: "auto"

--- a/ansible/roles/airgap_rke2_install/tasks/main.yml
+++ b/ansible/roles/airgap_rke2_install/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
+- name: Detect whether standalone traefik tarball is shipped by this RKE2 release
+  ansible.builtin.set_fact:
+    rke2_traefik_tarball_enabled: >-
+      {{
+        (rke2_traefik_tarball == 'auto') | ternary(
+          (((rke2_version | regex_replace('^v', '')).split('+')[0]) is version('1.36.0', '<')),
+          (rke2_traefik_tarball | bool)
+        )
+      }}
+
+- name: Show traefik tarball decision
+  ansible.builtin.debug:
+    msg: >-
+      Standalone traefik tarball for RKE2 {{ rke2_version }}:
+      {{ 'INCLUDED' if (rke2_traefik_tarball_enabled | bool) else 'SKIPPED (Traefik images are bundled in rke2-images-core on v1.36+)' }}
+
 - name: Create RKE2 config directory
   ansible.builtin.file:
     path: /etc/rancher/rke2
@@ -202,7 +218,9 @@
       ansible.builtin.stat:
         path: "{{ item }}"
       register: file_check
-      failed_when: not file_check.stat.exists
+      failed_when: >-
+        not file_check.stat.exists and
+        (item != '/tmp/rke2-artifacts/rke2-images-traefik.tar.gz' or (rke2_traefik_tarball_enabled | bool))
       loop:
         - /tmp/rke2-artifacts/rke2.linux-amd64.tar.gz
         - /tmp/rke2-artifacts/rke2-images-core.tar.gz
@@ -219,7 +237,7 @@
           - RKE2 tarball: {{ file_check.results[0].stat.exists }}
           - Core images: {{ file_check.results[1].stat.exists }}
           - CNI images ({{ cni | default('canal') }}): {{ file_check.results[2].stat.exists }}
-          - Traefik ingress images: {{ file_check.results[3].stat.exists }}
+          - Traefik ingress images: {{ file_check.results[3].stat.exists }}{{ '' if (rke2_traefik_tarball_enabled | bool) else ' (bundled in core)' }}
           - Checksums file: {{ file_check.results[4].stat.exists }}
           - Install script: {{ file_check.results[5].stat.exists }}
       run_once: true
@@ -241,9 +259,17 @@
   loop:
     - /tmp/rke2-artifacts/rke2-images-core.tar.gz
     - /tmp/rke2-artifacts/rke2-images-cni.tar.gz
-    - /tmp/rke2-artifacts/rke2-images-traefik.tar.gz
   loop_control:
     label: "{{ item | basename }}"
+
+- name: Copy Traefik ingress images to proper location
+  ansible.builtin.copy:
+    src: /tmp/rke2-artifacts/rke2-images-traefik.tar.gz
+    dest: /var/lib/rancher/rke2/agent/images/
+    remote_src: true
+    mode: "0644"
+  become: true
+  when: rke2_traefik_tarball_enabled | bool
 
 - name: Run RKE2 server install script
   ansible.builtin.shell: |


### PR DESCRIPTION
## Problem

RKE2 **v1.36** no longer publishes the standalone `rke2-images-traefik.*` tarball — the Traefik ingress images are now bundled inside `rke2-images-core.tar.gz`, and Traefik is the default ingress following the upstream `ingress-nginx` retirement (see the [v1.36.2+rke2r1 release notes](https://github.com/rancher/rke2/releases/tag/v1.36.2%2Brke2r1)):

> **Airgapped Environments:** The `rke2-images-core` tarball now contains Traefik images instead of `ingress-nginx`. The standalone `rke2-images-traefik` tarball has been removed.

The airgap roles hard-coded that tarball across the download, checksum, staging, and install steps, so a deploy against the current `rke2_version: v1.36.2+rke2r1` breaks:
- `get_url` 404s on `rke2-images-traefik.linux-<arch>.tar.gz` (asset no longer exists)
- checksum verification fails (no `traefik` line in `sha256sum-<arch>.txt`)
- install aborts on the `Verify required files` stat check + the image-copy loop

## Fix

Version-gated **auto-detection**: the roles now detect `rke2_version` and skip the standalone traefik tarball automatically for **>= 1.36** (Traefik loads from `rke2-images-core.tar.gz`), while keeping it for **<= v1.35**. No private-registry mirror of Traefik is required.

A `rke2_traefik_tarball` override (`"auto"` | `true` | `false`) is added for manual control.

### Detection logic (in both roles)
```jinja
(rke2_traefik_tarball == 'auto') | ternary(
  (((rke2_version | regex_replace('^v','')).split('+')[0]) is version('1.36.0', '<')),
  (rke2_traefik_tarball | bool)
)
```

## Changes
| File | Change |
|------|--------|
| `airgap_rke2_bundle_manager/tasks/download_artifacts.yml` | Detect + gate the traefik `get_url` |
| `airgap_rke2_bundle_manager/tasks/verify_checksums.yml` | Gate traefik checksum verify; safe-guard the result/fail/confirm refs when skipped |
| `airgap_rke2_bundle_manager/tasks/create_bundle.yml` | Gate the traefik staging copy |
| `airgap_rke2_install/tasks/main.yml` | Detect + relax the `stat` abort + split the image-copy loop |
| `airgap_rke2_bundle_manager/defaults/main.yml` | New `rke2_traefik_tarball: "auto"` var |
| `airgap_rke2_install/defaults/main.yml` | New `rke2_traefik_tarball: "auto"` var (role previously had no `defaults/`) |
| `rke2/airgap/README.md` | v1.36 callout + document the new variable |

## Validation
- **Gate logic**: asserted v1.36.0 / v1.36.2 / v1.37.0 → skip; v1.31.11 / v1.34.3 / v1.35.5 → include; override `true`/`false` wins over auto — all pass.
- **Lint**: only pre-existing rule categories (`var-naming[no-role-prefix]` is the repo-wide `rke2_*` convention, 51 existing), `command-instead-of-shell`, `no-changed-when`. No new findings introduced; no `yaml[line-length]`.
- **Compile**: `ansible-playbook --syntax-check` clean on both `rke2-tarball-playbook.yml` and `rke2-upgrade-playbook.yml`; static `import_tasks` deep-compile of all 4 edited task files clean (caught & fixed a structural merge of the checksum-failure block during dev).
