### PR TITLE
Add make targets to list cluster container images and digests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,8 @@ help: ## Show this help message
 	@echo ""
 	@echo "UTILITIES:"
 	@echo "  status              Show cluster status"
+	@echo "  images              List all container images and tags running in the cluster"
+	@echo "  images-digests      List pulled image digests (true versions behind mutable tags)"
 	@echo "  rancher-info        Display Rancher login information (URL, admin password, API token)"
 	@echo "  test-ssh            Test SSH connectivity to all nodes"
 	@echo "  ssh-bastion         SSH to bastion host"
@@ -651,6 +653,38 @@ status: check-inventory ## Show cluster status
 	else \
 		echo "No kubeconfig found at $(KUBECONFIG_FILE)"; \
 		echo "Run 'make cluster' first to deploy the cluster."; \
+	fi
+
+.PHONY: images
+images: check-inventory ## List all container images and tags running in the cluster
+	@echo "Container Images ($(DISTRO)/$(ENV)):"
+	@echo ""
+	@set -o pipefail; if [ "$(ENV)" = "airgap" ]; then \
+		echo "(airgap: reporting the cluster configured on the bastion — see 'make kubectl-setup')"; \
+		export ANSIBLE_CONFIG=$(ANSIBLE_DIR)/ansible.cfg; \
+		ansible -i $(INVENTORY) bastion -m shell -a "command -v kubectl >/dev/null 2>&1 && kubectl get pods -A -o jsonpath='{..image}' | tr -s '[[:space:]]' '\n' | sort -u" || echo "Could not list images — is kubectl set up on the bastion? Run 'make kubectl-setup' first."; \
+	elif [ -f "$(KUBECONFIG_FILE)" ]; then \
+		kubectl --kubeconfig $(KUBECONFIG_FILE) get pods -A -o jsonpath='{..image}' | tr -s '[[:space:]]' '\n' | sort -u || echo "Could not list images"; \
+	else \
+		echo "No kubeconfig found at $(KUBECONFIG_FILE)"; \
+		echo "Run 'make cluster' first to deploy the cluster."; \
+		exit 1; \
+	fi
+
+.PHONY: images-digests
+images-digests: check-inventory ## List pulled image digests (true versions behind mutable tags)
+	@echo "Container Image Digests ($(DISTRO)/$(ENV)):"
+	@echo ""
+	@set -o pipefail; if [ "$(ENV)" = "airgap" ]; then \
+		echo "(airgap: reporting the cluster configured on the bastion — see 'make kubectl-setup')"; \
+		export ANSIBLE_CONFIG=$(ANSIBLE_DIR)/ansible.cfg; \
+		ansible -i $(INVENTORY) bastion -m shell -a "command -v kubectl >/dev/null 2>&1 && kubectl get pods -A -o jsonpath='{..imageID}' | tr -s '[[:space:]]' '\n' | sort -u | grep -v '^$$'" || echo "Could not list images — is kubectl set up on the bastion? Run 'make kubectl-setup' first."; \
+	elif [ -f "$(KUBECONFIG_FILE)" ]; then \
+		kubectl --kubeconfig $(KUBECONFIG_FILE) get pods -A -o jsonpath='{..imageID}' | tr -s '[[:space:]]' '\n' | sort -u | grep -v '^$$' || echo "Could not list images"; \
+	else \
+		echo "No kubeconfig found at $(KUBECONFIG_FILE)"; \
+		echo "Run 'make cluster' first to deploy the cluster."; \
+		exit 1; \
 	fi
 
 .PHONY: rancher-info


### PR DESCRIPTION
## Summary

Adds two Makefile UTILITIES targets that list what's running in the Kubernetes cluster, modeled on the existing `status` target's `ENV` branching:

| Target | Purpose |
| --- | --- |
| `make images` | Unique, sorted list of `image:tag` strings across all namespaces |
| `make images-digests` | Resolved `imageID` digests — reveals the true version behind mutable tags like `:latest` |

Both use kubectl JSONPath recursive descent (`{..image}` / `{..imageID}`) piped through `tr`/`sort`/`grep` for a clean, de-duplicated list.

- **Default env:** runs `kubectl --kubeconfig $(KUBECONFIG_FILE)` locally.
- **Airgap env:** runs kubectl **on the bastion** via `ansible -i $(INVENTORY) bastion -m shell -a "..."` (kubectl lives on the bastion; install it first with `make kubectl-setup ENV=airgap`).

## Usage

```bash
# default (local kubeconfig, after `make cluster`)
make images
make images-digests

# airgap (kubectl on the bastion, after `make kubectl-setup ENV=airgap`)
make images ENV=airgap
make images-digests ENV=airgap
```

## Design notes / deviations from `status`

- The airgap ansible call intentionally drops `2>/dev/null` so real failures (auth errors, missing kubectl on the bastion) are diagnosable instead of silently swallowed.
- The bastion guard is POSIX-compatible (`command -v kubectl >/dev/null 2>&1 && ...`) because the airgap bastion is Ubuntu, whose `/bin/sh` is **dash** — which does **not** support `set -o pipefail`. When kubectl is absent on the bastion, the guard surfaces the `"run 'make kubectl-setup' first"` hint.
- The default-path recipe keeps `set -o pipefail` (the recipe shell is the Makefile's `SHELL := /bin/bash`), so local kubectl failures propagate to the `|| echo` fallback.
- Missing-kubeconfig exits `1` (vs `status`'s `0`) for scriptability.

## Verification

- `make help` renders both entries aligned in the UTILITIES block.
- `make -n images` and `make -n images-digests ENV=airgap` expand correctly (`$$` → `$`, single-quoted JSONPath intact, dash-safe guard).
- Live-tested `make images ENV=airgap` against an airgap cluster — lists images correctly.

## Out of scope

- Pod→image mapping target (`images-pods`) intentionally deferred.
- Node-level image auditing via `crictl images` (would catch CronJob images with no active pod and pre-staged containerd images) noted as possible future work.
