### PR TITLE
[Dashboard] - Add --dashboard-dir flag to run.sh for local checkout testing

### DIFF
--- a/ansible/testing/dashboard-e2e/README.md
+++ b/ansible/testing/dashboard-e2e/README.md
@@ -44,9 +44,15 @@ cd ansible/testing/dashboard-e2e
 cp vars.yaml.example vars.yaml
 # Edit vars.yaml  --  at minimum you need to set the AWS variables
 
-# 2. Export AWS credentials (secrets — don't put these in vars.yaml)
+# 2. Export credentials (secrets - don't put these in vars.yaml)
 export AWS_ACCESS_KEY_ID="..."
 export AWS_SECRET_ACCESS_KEY="..."
+
+# Optional: for AKS/GKE cluster tests
+export AZURE_AKS_SUBSCRIPTION_ID="..."
+export AZURE_CLIENT_ID="..."
+export AZURE_CLIENT_SECRET="..."
+export GKE_SERVICE_ACCOUNT="..."
 
 # 3. Run the full pipeline
 ansible-playbook dashboard-e2e-playbook.yml
@@ -59,7 +65,7 @@ ansible-playbook dashboard-e2e-playbook.yml
 
 ### Containerized wrapper (run.sh)
 
-The `run.sh` wrapper runs everything inside a container — the only prerequisite
+The `run.sh` wrapper runs everything inside a container. The only prerequisite
 is Docker or Podman. Commands are simple verbs that can be combined:
 
 ```bash
@@ -69,7 +75,7 @@ is Docker or Podman. Commands are simple verbs that can be combined:
 # Provision + setup + test with live Cypress output
 ./run.sh stream provision
 
-# Setup + test (most common — iterate on provisioned infra)
+# Setup + test (most common, iterate on provisioned infra)
 ./run.sh stream
 
 # Re-run tests only (after changing cypress_tags)
@@ -86,6 +92,9 @@ is Docker or Podman. Commands are simple verbs that can be combined:
 
 # Rebuild the runner image
 ./run.sh build
+
+# Use a local dashboard checkout (skip clone)
+./run.sh stream --dashboard-dir ~/repos/dashboard
 
 # Pass extra ansible flags
 ./run.sh test -v          # verbose
@@ -149,12 +158,23 @@ usage, run setup only, then Docker manually:
 # Setup: clone dashboard, build image, generate .env
 ansible-playbook dashboard-e2e-playbook.yml --tags setup
 
-# Run Cypress with real-time streaming
+# Run Cypress with real-time streaming (default cloned checkout)
 docker run --rm -t \
   --shm-size=2g \
   --env-file .env \
   -e NODE_PATH="" \
   -v "$PWD/dashboard:/e2e" \
+  -w /e2e \
+  dashboard-test:latest
+
+# Or run Cypress with your local checkout (unprivileged user):
+docker run --rm -it \
+  --user "$(id -u):$(id -g)" \
+  --shm-size=2g \
+  --env-file .env \
+  -e HOME=/tmp \
+  -e KUBECONFIG=/root/.kube/config \
+  -v /path/to/your/dashboard:/e2e \
   -w /e2e \
   dashboard-test:latest
 ```
@@ -182,7 +202,7 @@ Tear down all AWS resources (EC2, Route53) created during provisioning.
 # With run.sh
 ./run.sh destroy
 
-# Or with direct Ansible (requires both tags — 'never' prevents accidental execution)
+# Or with direct Ansible (requires both tags; 'never' prevents accidental execution)
 ansible-playbook dashboard-e2e-playbook.yml --tags cleanup,never
 ```
 
@@ -220,10 +240,16 @@ environment variables.
 | `server_count` | `3` | Number of Rancher HA nodes (1 or 3) |
 
 The following are **required** and have no defaults. Export them as environment
-variables — don't put secrets in `vars.yaml`:
+variables. Do not put secrets in `vars.yaml`:
 
-- `AWS_ACCESS_KEY_ID` — AWS credentials
-- `AWS_SECRET_ACCESS_KEY` — AWS credentials
+| Variable | Purpose |
+|----------|--------|
+| `AWS_ACCESS_KEY_ID` | AWS credentials |
+| `AWS_SECRET_ACCESS_KEY` | AWS credentials |
+| `AZURE_AKS_SUBSCRIPTION_ID` | Azure subscription (for AKS cluster tests) |
+| `AZURE_CLIENT_ID` | Azure service principal (for AKS cluster tests) |
+| `AZURE_CLIENT_SECRET` | Azure service principal secret (for AKS cluster tests) |
+| `GKE_SERVICE_ACCOUNT` | GCP service account JSON (for GKE cluster tests) |
 
 The remaining AWS settings go in `vars.yaml`:
 `aws_ami`, `aws_route53_zone`, `aws_vpc`, `aws_subnet`, `aws_security_group`
@@ -243,7 +269,7 @@ The remaining AWS settings go in `vars.yaml`:
 Rancher is released through two pipelines: **Prime** (SUSE registry) and
 **Community** (Docker Hub). Each pipeline has production, RC, and alpha stages.
 
-Each repo is self-contained — chart and image are resolved from the same source.
+Each repo is self-contained: chart and image are resolved from the same source.
 For Prime staging repos (`rancher-latest`, `rancher-alpha`), the resolved chart
 version becomes the image tag (e.g. `2.14.0-alpha13` → `v2.14.0-alpha13`).
 
@@ -259,27 +285,27 @@ version becomes the image tag (e.g. `2.14.0-alpha13` → `v2.14.0-alpha13`).
 ### Examples
 
 ```yaml
-# Prime stable — released 2.13.4
+# Prime stable - released 2.13.4
 rancher_helm_repo: "rancher-prime"
 rancher_image_tag: "v2.13.4"
 # → chart 2.13.4 from rancher-prime, image registry.suse.com/rancher/rancher:v2.13.4
 
-# Prime RC — test the latest 2.13 release candidate
+# Prime RC - test the latest 2.13 release candidate
 rancher_helm_repo: "rancher-latest"
 rancher_image_tag: "v2.13"
 # → highest 2.13.x-rc from optimus/latest, image stgregistry.suse.com/rancher/rancher:v2.13.4-rc1
 
-# Prime alpha — test the next minor
+# Prime alpha - test the next minor
 rancher_helm_repo: "rancher-alpha"
 rancher_image_tag: "v2.14"
 # → highest 2.14.x-alpha from optimus/alpha, image stgregistry.suse.com/rancher/rancher:v2.14.0-alpha13
 
-# Community GA — stable community release
+# Community GA - stable community release
 rancher_helm_repo: "rancher-community"
 rancher_image_tag: "v2.13.3"
 # → chart 2.13.3 from releases.rancher.com/stable, image rancher/rancher:v2.13.3
 
-# Community RC (default) — test upcoming community release
+# Community RC (default) - test upcoming community release
 rancher_helm_repo: "rancher-com-rc"
 rancher_image_tag: "v2.14-head"
 # → latest 2.14.x chart from releases.rancher.com/latest, image rancher/rancher:v2.14-head
@@ -289,7 +315,7 @@ rancher_helm_repo: "rancher-com-alpha"
 rancher_image_tag: "v2.14.0-alpha9"
 # → chart 2.14.0-alpha9 from releases.rancher.com/alpha, image rancher/rancher:v2.14.0-alpha9
 
-# Dev head — latest from any repo
+# Dev head - latest from any repo
 rancher_helm_repo: "rancher-com-rc"
 rancher_image_tag: "head"
 # → latest chart in the repo, image rancher/rancher:head
@@ -306,6 +332,35 @@ rancher_image_tag: "head"
 | `dashboard_repo` | `rancher/dashboard` | Dashboard GitHub repo to clone |
 | `dashboard_branch` | (auto-detected) | Branch to clone. Auto-detected from `rancher_image_tag` (e.g. `v2.14-head` → `release-2.14`) |
 | `dashboard_overlay_branch` | `master` | Branch to overlay dependency files from (package.json, yarn.lock, cypress.config.ts). CI files come from the playbook's `files/` directory |
+
+### Using a local dashboard checkout
+
+The `--dashboard-dir` flag lets you point at your own local `rancher/dashboard`
+checkout instead of cloning from GitHub. The playbook skips the clone, overlay,
+and delete steps. Your working tree is mounted directly into the containers.
+
+```bash
+# Setup + test with live output, using your local repo
+./run.sh stream --dashboard-dir ~/repos/dashboard
+
+# Re-run tests (reuses the image, your local edits are picked up)
+./run.sh stream test --dashboard-dir ~/repos/dashboard
+```
+
+This is useful when:
+- You want to test **uncommitted changes** without pushing to a remote
+- You want to avoid the clone/overlay cycle during iteration
+- You have a large dashboard checkout and don't want to duplicate it
+
+> **Important:** When using `--dashboard-dir`, `dashboard_repo` and `dashboard_branch`
+> (for example `dashboard_repo: "izaac/dashboard"` or `dashboard_branch: "issue-2459"`)
+> are **ignored** because the local checkout is used instead of cloning. Developers and QA
+> are responsible for ensuring that their local code branch is compatible with the targeted
+> `rancher_helm_repo` and `rancher_image_tag`, otherwise tests may fail with unexpected UI errors.
+
+> **Note:** The setup stage copies a few CI files (`Dockerfile.ci`, `cypress.sh`,
+> etc.) into `cypress/jenkins/` in your checkout to build the test image. Clean
+> them with `git checkout -- cypress/jenkins/` if needed.
 
 ### Pinned versions
 
@@ -345,7 +400,7 @@ Example: Input `@userMenu` with repo `rancher-com-rc` becomes
 | `test` | Cypress Docker run + result collection |
 | `cleanup` | Infrastructure teardown (requires `--tags cleanup,never`) |
 
-Pre-tasks (validation, tag adjustment) use `always` with conditional guards —
+Pre-tasks (validation, tag adjustment) use `always` with conditional guards;
 they are evaluated on every run but skip work that doesn't apply (e.g. Cypress
 tag adjustment is skipped during `cleanup`, host validation is skipped when
 `provision` will create it).
@@ -383,7 +438,7 @@ dashboard-e2e-playbook.yml          Main orchestrator
 
 files/                               CI files (copied into dashboard clone at setup)
   Dockerfile.ci                      Cypress factory image + kubectl
-  cypress.sh                         Container entrypoint — runs Cypress + jrm
+  cypress.sh                         Container entrypoint (runs Cypress + jrm)
   cypress.config.jenkins.ts          Cypress config (reporters, retries, Qase)
   grep-filter.ts                     Pre-filter specs by tag
   utils.sh                           Shared shell utilities (clean_tags, etc.)
@@ -391,14 +446,14 @@ files/                               CI files (copied into dashboard clone at se
 
 ### Key Scripts and Tasks
 
-- **`files/`** — CI files that are infrastructure concern, not test code.
+- **`files/`** contains CI files that are an infrastructure concern, not test code.
   The playbook copies them into the dashboard clone during setup, making the
   playbook fully self-contained. No git overlay needed for CI files.
-- **`rancher_user_setup` role** (`ansible/roles/rancher_user_setup/`) — Creates
+- **`rancher_user_setup` role** (`ansible/roles/rancher_user_setup/`) creates
   Rancher local users with global and project role bindings via the Rancher API.
   Parameterized: accepts a list of users, roles, and project bindings. Idempotent
   (skips if resources already exist). Error handling configurable (`fail` or `warn`).
-- **`files/grep-filter.ts`** — Pre-filters Cypress spec files by tag before
+- **`files/grep-filter.ts`** pre-filters Cypress spec files by tag before
   Cypress launches. Runs inside the Docker container to reduce unnecessary
   spec loading.
 
@@ -438,19 +493,19 @@ macOS and most Linux distros. On minimal systems: `apt-get install xxd`.
 
 ### Shell compatibility
 
-All shell tasks in the playbook are POSIX-compatible (`/bin/sh`). No `/bin/bash`
-dependency — the playbook runs on any system with a POSIX shell.
+All shell tasks in the playbook are POSIX-compatible (`/bin/sh`). There is no
+`/bin/bash` dependency; the playbook runs on any system with a POSIX shell.
 
 ## Dependencies
 
 Ansible collections required (install manually or let `init.sh` handle it in Jenkins):
 
-- `cloud.terraform` — required by the shared `ansible/k3s/default/k3s-playbook.yml` as a
+- `cloud.terraform` is required by the shared `ansible/k3s/default/k3s-playbook.yml` as a
   fallback when `kube_api_host`/`fqdn` are absent from the inventory. dashboard-e2e
   itself no longer relies on this path: `scripts/generate_inventory.py` bakes both
   values into `all.vars`, so the lookup is inert during normal runs.
-- `kubernetes.core` — Kubernetes resource operations
-- `community.docker` **< 5** — Docker image build and container
-  management (v5+ requires ansible-core ≥ 2.17)
-- `community.crypto` **< 3** — SSH keypair generation
-  (v3+ requires ansible-core ≥ 2.17)
+- `kubernetes.core` for Kubernetes resource operations.
+- `community.docker` **< 5** for Docker image build and container
+  management (v5+ requires ansible-core ≥ 2.17).
+- `community.crypto` **< 3** for SSH keypair generation
+  (v3+ requires ansible-core ≥ 2.17).

--- a/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
+++ b/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
@@ -27,7 +27,7 @@
     # Paths
     qa_infra_dir: "{{ lookup('env', 'QA_INFRA_DIR') | default(playbook_dir | dirname | dirname | dirname, true) }}"
     outputs_dir: "{{ workspace_dir }}/outputs"
-    dashboard_dir: "{{ workspace_dir }}/dashboard"
+    dashboard_dir: "{{ dashboard_src | default(workspace_dir + '/dashboard') }}"
     host_dashboard_dir: "{{ lookup('env', 'HOST_DASHBOARD_DIR') | default(dashboard_dir, true) }}"
     workspace_dir: "{{ lookup('env', 'WORKSPACE') | default(playbook_dir, true) }}"
     tofu_module: "{{ qa_infra_dir }}/tofu/aws/modules/cluster_nodes"

--- a/ansible/testing/dashboard-e2e/files/Dockerfile.ci
+++ b/ansible/testing/dashboard-e2e/files/Dockerfile.ci
@@ -30,6 +30,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /root/.kube
 
-COPY imported_config /root/.kube/config
+COPY --chmod=644 imported_config /root/.kube/config
 
 ENTRYPOINT ["bash", "cypress/jenkins/cypress.sh"]

--- a/ansible/testing/dashboard-e2e/files/grep-filter.ts
+++ b/ansible/testing/dashboard-e2e/files/grep-filter.ts
@@ -34,11 +34,14 @@ if (!grepTags) {
   process.exit(0);
 }
 
+const testSkip: string = process.env.TEST_SKIP || '';
+const skipSetup: boolean = testSkip.includes('setup') || process.env.TEST_SKIP_SETUP === 'true';
+
 // IMPORTANT: keep in sync with testDirs in cypress.config.jenkins.ts
 const testDirs: string[] = [
   'cypress/e2e/tests/priority/**/*.spec.ts',
   'cypress/e2e/tests/components/**/*.spec.ts',
-  'cypress/e2e/tests/setup/**/*.spec.ts',
+  ...(skipSetup ? [] : ['cypress/e2e/tests/setup/**/*.spec.ts']),
   'cypress/e2e/tests/pages/**/*.spec.ts',
   'cypress/e2e/tests/navigation/**/*.spec.ts',
   'cypress/e2e/tests/global-ui/**/*.spec.ts',

--- a/ansible/testing/dashboard-e2e/run.sh
+++ b/ansible/testing/dashboard-e2e/run.sh
@@ -17,6 +17,9 @@
 #   ./run.sh results                  # open the HTML test report
 #   ./run.sh clean                    # remove local artifacts (reports, clone, .env)
 #
+# Options:
+#   --dashboard-dir <path>           use a local dashboard checkout (skip clone)
+#
 # Extra ansible flags pass through:
 #   ./run.sh test -v                  # verbose
 #   ./run.sh test --check             # dry-run
@@ -126,18 +129,31 @@ run_playbook() {
 	# Ansible requires a valid YAML dict; fall back to empty mapping if no creds were written
 	[ ! -s "${_creds_file}" ] && printf '{}\n' > "${_creds_file}"
 
+	# When --dashboard-dir is set, mount the external dir and pass it as an Ansible var
+	_dashboard_docker_args=""
+	_dashboard_ansible_args=""
+	if [ -n "${DASHBOARD_DIR:-}" ]; then
+		_dashboard_docker_args="-v ${DASHBOARD_DIR}:/external-dashboard"
+		_dashboard_ansible_args='--extra-vars dashboard_src=/external-dashboard'
+	fi
+
+	# shellcheck disable=SC2086
 	$RUNTIME run --rm -it \
 		-v "${SOCKET}:/var/run/docker.sock" \
 		-v "${VARS_FILE}:/playbook/vars.yaml:ro" \
 		-v "${_creds_file}:/playbook/.creds.yml:ro" \
 		-v "${SCRIPT_DIR}:/playbook" \
 		-v "${REPO_ROOT}:/qa-infra" \
+		${_dashboard_docker_args} \
 		-e QA_INFRA_DIR=/qa-infra \
-		-e HOST_DASHBOARD_DIR="${SCRIPT_DIR}/dashboard" \
+		-e HOST_DASHBOARD_DIR="${DASHBOARD_DIR:-${SCRIPT_DIR}/dashboard}" \
+		-e HOST_UID="$(id -u)" \
+		-e HOST_GID="$(id -g)" \
 		-e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}" \
 		-e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}" \
 		"$IMAGE_NAME" \
 		--extra-vars "@/playbook/.creds.yml" \
+		${_dashboard_ansible_args} \
 		"$@"
 
 	rm -f "${_creds_file}"
@@ -164,10 +180,13 @@ stream_cypress() {
 
 	exec $RUNTIME run --rm -it \
 		--name "$_name" \
+		--user "$(id -u):$(id -g)" \
 		--shm-size=2g \
 		--env-file "${SCRIPT_DIR}/.env" \
+		-e HOME=/tmp \
+		-e KUBECONFIG=/root/.kube/config \
 		-e NODE_PATH="" \
-		-v "${SCRIPT_DIR}/dashboard:/e2e" \
+		-v "${DASHBOARD_DIR:-${SCRIPT_DIR}/dashboard}:/e2e" \
 		-w /e2e \
 		dashboard-test:0
 }
@@ -182,6 +201,7 @@ STREAM=""
 _FORCE_BUILD=""
 _BUILD_ONLY=""
 _EXCL=""
+DASHBOARD_DIR=""
 
 # destroy and build run on their own; refuse to mix them with stage verbs so a
 # request like "provision destroy" can never silently drop or reorder stages.
@@ -236,6 +256,18 @@ while [ $# -gt 0 ]; do
 	-h | --help)
 		sed -n '2,/^$/s/^# //p' "$0"
 		exit 0
+		;;
+	--dashboard-dir)
+		if [ -z "${2:-}" ]; then
+			echo "ERROR: --dashboard-dir requires a path argument." >&2
+			exit 2
+		fi
+		if [ ! -d "$2" ]; then
+			echo "ERROR: --dashboard-dir path '$2' does not exist." >&2
+			exit 2
+		fi
+		DASHBOARD_DIR="$(cd "$2" && pwd)"
+		shift 2
 		;;
 	-*)
 		# Unknown flag: stop parsing and forward it (and the rest) to ansible.
@@ -295,6 +327,12 @@ if [ -n "$_BUILD_ONLY" ]; then
 fi
 
 mkdir -p "${SCRIPT_DIR}/outputs"
+
+if [ -n "${DASHBOARD_DIR:-}" ]; then
+	echo "[run] Using local dashboard: ${DASHBOARD_DIR}"
+	echo "[run] WARNING: --dashboard-dir overrides dashboard_repo and dashboard_branch (git clone skipped)."
+	echo "[run] Ensure your local code is compatible with rancher_helm_repo and rancher_image_tag."
+fi
 
 echo "[run] Using ${RUNTIME} (socket: ${SOCKET})"
 echo "[run] vars.yaml: ${VARS_FILE}"

--- a/ansible/testing/dashboard-e2e/tasks/run-tests.yml
+++ b/ansible/testing/dashboard-e2e/tasks/run-tests.yml
@@ -12,8 +12,15 @@
 
 - name: Run Cypress tests in Docker
   ansible.builtin.shell: |
+    USER_ARG=""
+    HOST_UID="{{ lookup('env', 'HOST_UID') }}"
+    HOST_GID="{{ lookup('env', 'HOST_GID') }}"
+    if [ -n "$HOST_UID" ] && [ -n "$HOST_GID" ]; then
+      USER_ARG="--user $HOST_UID:$HOST_GID -e HOME=/tmp -e KUBECONFIG=/root/.kube/config"
+    fi
     docker run --rm -t --init \
       --name "cypress-{{ executor_tag }}-{{ prefix | default('local') | lower | regex_replace('[^a-z0-9_.-]', '-') }}-{{ rancher_host | default('dashboard-e2e') | lower | regex_replace('[^a-z0-9_.-]', '-') }}" \
+      $USER_ARG \
       --shm-size=2g \
       --env-file "{{ workspace_dir }}/.env" \
       -e NODE_PATH="" \
@@ -31,7 +38,11 @@
 
 - name: Fix dashboard permissions after Docker run
   ansible.builtin.shell: |
-    chown -R "$(id -u):$(id -g)" "{{ dashboard_dir }}" 2>/dev/null || true
+    HOST_UID="{{ lookup('env', 'HOST_UID') }}"
+    HOST_GID="{{ lookup('env', 'HOST_GID') }}"
+    if [ -n "$HOST_UID" ] && [ -n "$HOST_GID" ]; then
+      chown -R "$HOST_UID:$HOST_GID" "{{ dashboard_dir }}" 2>/dev/null || true
+    fi
   changed_when: false
 
 - name: Set test exit code

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -13,6 +13,29 @@
   retries: 30
   delay: 10
 
+- name: Validate local dashboard directory
+  when: dashboard_src is defined
+  block:
+    - name: Stat local dashboard directory
+      ansible.builtin.stat:
+        path: "{{ dashboard_dir }}"
+      register: _local_dashboard_stat
+
+    - name: Assert local dashboard directory exists and is valid
+      ansible.builtin.assert:
+        that:
+          - _local_dashboard_stat.stat.exists
+          - _local_dashboard_stat.stat.isdir
+        fail_msg: "dashboard_src directory '{{ host_dashboard_dir }}' does not exist or is not a directory."
+
+    - name: Display local dashboard directory notice
+      ansible.builtin.debug:
+        msg: >-
+          NOTICE: Using local dashboard directory '{{ host_dashboard_dir }}'.
+          Git clone is skipped; dashboard_repo and dashboard_branch are ignored.
+          Ensure your local code is compatible with rancher_helm_repo ('{{ rancher_helm_repo }}')
+          and rancher_image_tag ('{{ rancher_image_tag }}').
+
 - name: Detect dashboard target branch
   ansible.builtin.set_fact:
     target_branch: >-
@@ -25,19 +48,23 @@
       {%- else -%}
         {{ dashboard_branch | default('master') }}
       {%- endif -%}
+  when: dashboard_src is not defined
 
 - name: Show detected branch
   ansible.builtin.debug:
     msg: "rancher_image_tag={{ rancher_image_tag }} → target_branch={{ target_branch }}"
+  when: dashboard_src is not defined
 
 - name: Remove old dashboard checkout
   ansible.builtin.file:
     path: "{{ dashboard_dir }}"
     state: absent
+  when: dashboard_src is not defined
 
 - name: Show clone target
   ansible.builtin.debug:
     msg: "Cloning {{ dashboard_repo }} @ {{ target_branch }}"
+  when: dashboard_src is not defined
 
 - name: Clone dashboard repo
   ansible.builtin.git:
@@ -49,6 +76,7 @@
   delay: 10
   register: _git_clone
   until: _git_clone is success
+  when: dashboard_src is not defined
 
 - name: Copy CI files from playbook into dashboard checkout
   ansible.builtin.copy:
@@ -83,7 +111,9 @@
     git checkout FETCH_HEAD -- cypress/support/qase.ts 2>/dev/null || \
       echo "[overlay] NOTICE: cypress/support/qase.ts not found on ${OVERLAY_BRANCH}, skipping"
     echo "[overlay] OK — overlaid dependency files from ${OVERLAY_BRANCH} onto {{ target_branch }}"
-  when: target_branch != (dashboard_overlay_branch | default('master', true))
+  when:
+    - dashboard_src is not defined
+    - target_branch != (dashboard_overlay_branch | default('master', true))
   changed_when: true
 
 - name: Configure Rancher users and role bindings
@@ -194,6 +224,18 @@
       Cypress={{ cypress_version }}, Node={{ nodejs_version }},
       Chrome={{ chrome_version }}
 
+- name: Write .dockerignore for build context
+  ansible.builtin.copy:
+    content: |
+      .git
+      node_modules
+      cypress/downloads
+      cypress/screenshots
+      cypress/videos
+      cypress/reports
+    dest: "{{ dashboard_dir }}/.dockerignore"
+    mode: "0644"
+
 - name: Build dashboard-test Docker image
   ansible.builtin.shell: |
     set -e
@@ -206,6 +248,15 @@
       --build-arg CHROME_VERSION="{{ chrome_version }}" \
       "{{ dashboard_dir }}"
   changed_when: true
+
+- name: Fix dashboard permissions after Docker build
+  ansible.builtin.shell: |
+    HOST_UID="{{ lookup('env', 'HOST_UID') }}"
+    HOST_GID="{{ lookup('env', 'HOST_GID') }}"
+    if [ -n "$HOST_UID" ] && [ -n "$HOST_GID" ]; then
+      chown -R "$HOST_UID:$HOST_GID" "{{ dashboard_dir }}" 2>/dev/null || true
+    fi
+  changed_when: false
 
 - name: Generate .env file
   ansible.builtin.template:

--- a/ansible/testing/dashboard-e2e/templates/env.j2
+++ b/ansible/testing/dashboard-e2e/templates/env.j2
@@ -5,8 +5,12 @@ CYPRESS_VIEWPORT_HEIGHT=660
 TEST_BASE_URL=https://{{ rancher_host }}/dashboard
 TEST_USERNAME={{ 'standard_user' if '@standardUser' in cypress_tags else rancher_username | default('admin') }}
 TEST_PASSWORD={{ rancher_password }}
+{% if '@setup' in cypress_tags or 'Setup' in cypress_tags %}
+# Setup tags explicitly requested in cypress_tags — do not skip setup
+{% else %}
 TEST_SKIP_SETUP=true
 TEST_SKIP=setup
+{% endif %}
 AWS_ACCESS_KEY_ID={{ aws_access_key_id }}
 AWS_SECRET_ACCESS_KEY={{ aws_secret_access_key }}
 {% if azure_client_id | default('') | length > 0 %}


### PR DESCRIPTION
Adds the `--dashboard-dir <path>` flag to `run.sh` so you can point E2E test runs at a local `rancher/dashboard` checkout instead of cloning from GitHub every time.

### What's included:
- **`run.sh` & Ansible:** Mounts the local checkout into the runner container and skips git clone/overlay steps when the flag is passed.
- **Permissions:** Passes host UID/GID down to the container so test reports, downloads, and generated files stay owned by your host user instead of root.
- **Setup test skipping:** Fixes `grep-filter.ts` to respect `TEST_SKIP=setup` like upstream `base-config.ts` does, preventing `rancher-setup.spec.ts` from running unexpectedly.
- **Docs:** Added usage examples and notes to `README.md`.

Tested locally across provisioning modes with and without the flag.