### PR TITLE
[Dashboard] - Build Dockerfile.ci with the legacy Docker builder

### DIFF
--- a/ansible/testing/dashboard-e2e/files/Dockerfile.ci
+++ b/ansible/testing/dashboard-e2e/files/Dockerfile.ci
@@ -30,6 +30,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /root/.kube
 
-COPY --chmod=644 imported_config /root/.kube/config
+# `COPY --chmod` is a BuildKit-only flag and the Jenkins agents build with the
+# legacy builder, so the mode is set in a separate step that both builders
+# accept. Mode 644 is required because local runs start the container with
+# `--user`, and that non-root user has to read the kubeconfig.
+COPY imported_config /root/.kube/config
+RUN chmod 644 /root/.kube/config
 
 ENTRYPOINT ["bash", "cypress/jenkins/cypress.sh"]

--- a/ansible/testing/dashboard-e2e/files/cypress.sh
+++ b/ansible/testing/dashboard-e2e/files/cypress.sh
@@ -144,7 +144,11 @@ echo "CYPRESS EXIT CODE: $EXIT_CODE"
 # Merge JUnit reports inside the container (Node.js is available here)
 echo "[cypress.sh] Merging JUnit reports..."
 if ! npx --no-install jrm results.xml "cypress/jenkins/reports/junit/junit-*"; then
-	echo "WARNING: jrm merge failed, individual junit-*.xml files may still be available"
+	echo "WARNING: jrm merge failed, so results.xml was not produced."
+	if ! npx --no-install jrm --version >/dev/null 2>&1; then
+		echo "WARNING: junit-report-merger is not installed in this checkout, which is why the merge could not run."
+	fi
+	echo "WARNING: individual junit-*.xml files may still be available:"
 	ls -la cypress/jenkins/reports/junit/ 2>/dev/null || echo "  (report directory not found)"
 fi
 

--- a/ansible/testing/dashboard-e2e/files/grep-filter.ts
+++ b/ansible/testing/dashboard-e2e/files/grep-filter.ts
@@ -20,8 +20,26 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
-const globby = require('globby') as { sync: (patterns: string[], opts: { cwd: string; ignore: string[]; absolute: boolean }) => string[] };
-const { getTestNames } = require('find-test-names') as { getTestNames: (text: string) => { tests: Array<{ tags: string[] }> } };
+// A checkout that does not declare these fails here with a bare module
+// resolution stack trace, which reads as a broken script rather than an
+// incomplete checkout. Name the package and the consequence instead.
+const requireOrExplain = (moduleName: string): unknown => {
+  try {
+    return require(moduleName);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException | undefined)?.code === 'MODULE_NOT_FOUND') {
+      console.error(`[grep-filter] '${ moduleName }' is not installed in this checkout.`);
+      console.error('[grep-filter] Spec pre-selection needs it, so tag filtering cannot run.');
+      console.error('[grep-filter] Branches from release-2.14 onwards carry it in cypress/package.json;');
+      console.error('[grep-filter] the clone path also overlays it from dashboard_overlay_branch.');
+      process.exit(1);
+    }
+    throw e;
+  }
+};
+
+const globby = requireOrExplain('globby') as { sync: (patterns: string[], opts: { cwd: string; ignore: string[]; absolute: boolean }) => string[] };
+const { getTestNames } = requireOrExplain('find-test-names') as { getTestNames: (text: string) => { tests: Array<{ tags: string[] }> } };
 
 // Resolve utils.js dynamically relative to the main entrypoint to bypass exports encapsulation in v6
 let parseGrep: (title: string | null, tags: string) => unknown;

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -309,72 +309,53 @@
       }}
   changed_when: false
 
+- name: Read Dockerfile.ci back
+  ansible.builtin.slurp:
+    src: "{{ dashboard_dir }}/cypress/jenkins/Dockerfile.ci"
+  register: _dockerfile_ci
+
+# Jenkins agents have no buildx, so docker build falls back to the legacy
+# builder. It rejects BuildKit only instructions outright, and the failure
+# surfaces as an opaque build error rather than a bad Dockerfile.
 - name: Reject BuildKit-only syntax in Dockerfile.ci
-  ansible.builtin.shell: |
-    set -e
-    if grep -nE '^[[:space:]]*(COPY|ADD)[[:space:]]+--(chmod|link|exclude)([[:space:]]|=)|^[[:space:]]*RUN[[:space:]]+--(mount|network|security)([[:space:]]|=)' \
-        "{{ dashboard_dir }}/cypress/jenkins/Dockerfile.ci"; then
-      echo "[verify] ERROR: the lines above use BuildKit-only Dockerfile syntax."
-      echo "[verify] Jenkins agents build with the legacy builder, which rejects it."
-      echo "[verify] Rewrite them so the image builds under both builders, for"
-      echo "[verify] example COPY followed by a separate RUN chmod."
-      exit 1
-    fi
-    echo "[verify] OK, Dockerfile.ci builds under the legacy builder"
-  changed_when: false
+  ansible.builtin.assert:
+    that: _buildkit_only | length == 0
+    success_msg: Dockerfile.ci builds under the legacy builder
+    fail_msg: >-
+      Dockerfile.ci uses BuildKit only syntax that the legacy builder on the
+      Jenkins agents rejects: {{ _buildkit_only | join(' / ') }}. Rewrite it so
+      the image builds under both builders, for example a plain COPY followed
+      by a separate RUN chmod.
+  vars:
+    _buildkit_only: >-
+      {{ (_dockerfile_ci.content | b64decode).splitlines()
+         | select('search', '^\s*((COPY|ADD)\s+--(chmod|link|exclude)|RUN\s+--(mount|network|security))[\s=]')
+         | list }}
 
-# The image caches the Cypress binary named by cypress_version, while the npm
-# package comes from cypress/package.json at container start. When they differ
-# Cypress downloads the pinned binary on every run, which is slow and fails
-# outright on hosts without access to download.cypress.io.
-- name: Check cypress_version against the pinned Cypress
-  ansible.builtin.shell: |
-    set -e
-    pinned=$(sed -n 's/.*"cypress"[[:space:]]*:[[:space:]]*"[~^]\{0,1\}\([0-9][^"]*\)".*/\1/p' \
-      "{{ dashboard_dir }}/cypress/package.json" | head -1)
-    if [ -n "${pinned}" ] && [ "${pinned}" != "{{ cypress_version }}" ]; then
-      echo "WARNING: cypress_version is {{ cypress_version }} but cypress/package.json pins ${pinned}."
-      echo "Set cypress_version to ${pinned} in vars.yaml, or in VARS_YAML_CONFIG on the Jenkins job."
-    fi
-  register: _cypress_pin
-  changed_when: false
+- name: Read the dashboard Cypress manifest
+  ansible.builtin.slurp:
+    src: "{{ dashboard_dir }}/cypress/package.json"
+  register: _cypress_manifest
 
+# The image bakes the binary named by cypress_version, while the npm package
+# comes from this manifest at container start. When they differ Cypress
+# downloads the pinned binary on every run, and fails outright on hosts with no
+# access to download.cypress.io.
 - name: Warn when cypress_version does not match the pinned Cypress
   ansible.builtin.debug:
-    msg: "{{ _cypress_pin.stdout_lines }}"
-  when: "'WARNING' in (_cypress_pin.stdout | default(''))"
-
-- name: Show Docker build args
-  ansible.builtin.debug:
     msg: >-
-      Building dashboard-test image:
-      Cypress={{ cypress_version }}, Node={{ nodejs_version }},
-      Chrome={{ chrome_version }}
-
-- name: Write .dockerignore for build context
-  ansible.builtin.copy:
-    content: |
-      .git
-      node_modules
-      cypress/downloads
-      cypress/screenshots
-      cypress/videos
-      cypress/reports
-    dest: "{{ dashboard_dir }}/.dockerignore"
-    mode: "0644"
-
-- name: Build dashboard-test Docker image
-  ansible.builtin.shell: |
-    set -e
-    docker build \
-      -t dashboard-test:{{ executor_tag }} \
-      -f "{{ dashboard_dir }}/cypress/jenkins/Dockerfile.ci" \
-      --build-arg YARN_VERSION="{{ yarn_version }}" \
-      --build-arg NODE_VERSION="{{ nodejs_version }}" \
-      --build-arg CYPRESS_VERSION="{{ cypress_version }}" \
-      --build-arg CHROME_VERSION="{{ chrome_version }}" \
-      "{{ dashboard_dir }}"
-  changed_when: true
+      WARNING: cypress_version is {{ cypress_version }} but
+      cypress/package.json pins {{ _pinned_cypress }}. Set cypress_version to
+      {{ _pinned_cypress }} in vars.yaml, or in VARS_YAML_CONFIG on the Jenkins
+      job.
+  vars:
+    _pinned_cypress: >-
+      {{ ((_cypress_manifest.content | b64decode | from_json).dependencies | default({})).cypress
+         | default(((_cypress_manifest.content | b64decode | from_json).devDependencies | default({})).cypress, true)
+         | default('', true) | regex_replace('^[~^]', '') }}
+  when:
+    - _pinned_cypress | length > 0
+    - _pinned_cypress != cypress_version
 
 # The docker build output is only shown when the build fails, so a successful
 # build says nothing about what actually landed in the image. That silence is

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -358,6 +358,45 @@
     - _pinned_cypress | length > 0
     - _pinned_cypress != cypress_version
 
+- name: Show Docker build args
+  ansible.builtin.debug:
+    msg: >-
+      Building dashboard-test image:
+      Cypress={{ cypress_version }}, Node={{ nodejs_version }},
+      Chrome={{ chrome_version }}
+
+- name: Write .dockerignore for build context
+  ansible.builtin.copy:
+    content: |
+      .git
+      node_modules
+      cypress/downloads
+      cypress/screenshots
+      cypress/videos
+      cypress/reports
+    dest: "{{ dashboard_dir }}/.dockerignore"
+    mode: "0644"
+
+- name: Build dashboard-test Docker image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - build
+      - -t
+      - "dashboard-test:{{ executor_tag }}"
+      - -f
+      - "{{ dashboard_dir }}/cypress/jenkins/Dockerfile.ci"
+      - --build-arg
+      - "YARN_VERSION={{ yarn_version }}"
+      - --build-arg
+      - "NODE_VERSION={{ nodejs_version }}"
+      - --build-arg
+      - "CYPRESS_VERSION={{ cypress_version }}"
+      - --build-arg
+      - "CHROME_VERSION={{ chrome_version }}"
+      - "{{ dashboard_dir }}"
+  changed_when: true
+
 # The docker build output is only shown when the build fails, so a successful
 # build says nothing about what actually landed in the image. That silence is
 # how a BuildKit only COPY flag reached Jenkins unnoticed. These tasks read the

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -376,6 +376,82 @@
       "{{ dashboard_dir }}"
   changed_when: true
 
+# The build output is only shown when the build fails, so a successful build
+# says nothing about what actually landed in the image. That silence is how a
+# BuildKit only COPY flag reached Jenkins unnoticed. These checks read the
+# facts back out of the finished image.
+#
+# Only deterministic in-image facts fail the run. The live cluster call is
+# reported and never fatal, because reachability is already asserted earlier by
+# "Wait for import cluster API" and a second network check here would only add
+# a new way for a good build to fail.
+- name: Verify the built image
+  ansible.builtin.shell: |
+    set -eu
+    image="dashboard-test:{{ executor_tag }}"
+    want_cypress="{{ cypress_version }}"
+    need_kubeconfig="{{ 'yes' if (create_initial_clusters | bool) else 'no' }}"
+    fail=""
+
+    in_image() {
+      docker run --rm --entrypoint sh "$image" -c "$1" 2>/dev/null
+    }
+
+    # Cypress ships one binary per version under CYPRESS_CACHE_FOLDER, while
+    # the npm package is installed at container start from cypress/package.json.
+    # A mismatch makes Cypress re-download the binary on every run and fail
+    # outright on hosts with no access to download.cypress.io.
+    if in_image "test -d /root/.cache/Cypress/$want_cypress"; then
+      echo "[image] OK   cypress binary $want_cypress present"
+    else
+      have=$(in_image 'ls /root/.cache/Cypress' | tr '\n' ' ' || true)
+      echo "[image] FAIL cypress binary $want_cypress missing, image holds: $have"
+      fail=yes
+    fi
+
+    if in_image 'command -v kubectl' >/dev/null; then
+      kver=$(in_image 'kubectl version --client 2>/dev/null | head -1' || true)
+      echo "[image] OK   kubectl ${kver:-present}"
+    else
+      echo "[image] FAIL kubectl missing, the imported cluster spec pipes into kubectl apply"
+      fail=yes
+    fi
+
+    if [ "$need_kubeconfig" = no ]; then
+      echo "[image] SKIP kubeconfig, create_initial_clusters is false"
+    elif in_image 'test -f /root/.kube/config'; then
+      echo "[image] OK   kubeconfig $(in_image 'ls -l /root/.kube/config' || true)"
+      # Local runs start the container with --user, so a non-root user has to
+      # be able to read it. Jenkins runs as root and would never notice.
+      mode=$(in_image 'stat -c %a /root/.kube/config' || true)
+      case "$mode" in
+        *[4567]) echo "[image] OK   kubeconfig mode $mode is world readable" ;;
+        *) echo "[image] FAIL kubeconfig mode ${mode:-unreadable} blocks the non-root user used by local runs"
+           fail=yes ;;
+      esac
+      # Informational only. Reachability is already asserted by "Wait for
+      # import cluster API", so failing here would only add a way for a good
+      # build to break.
+      echo "[image] ---- kubectl get nodes from inside the image, informational ----"
+      in_image 'kubectl --request-timeout=20s get nodes -o wide 2>&1 | head -8' \
+        | sed 's/^/[image] /' || echo "[image] NOTE could not reach the imported cluster from the image"
+    else
+      echo "[image] FAIL /root/.kube/config missing while create_initial_clusters is true"
+      fail=yes
+    fi
+
+    if [ -n "$fail" ]; then
+      echo "[image] one or more image checks failed"
+      exit 1
+    fi
+    echo "[image] image verified"
+  register: _image_verify
+  changed_when: false
+
+- name: Show image verification output
+  ansible.builtin.debug:
+    msg: "{{ _image_verify.stdout_lines }}"
+
 - name: Generate .env file
   ansible.builtin.template:
     src: env.j2

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -116,86 +116,87 @@
     - target_branch != (dashboard_overlay_branch | default('master', true))
   changed_when: true
 
-# Release branches (2.14/2.15) register grep via `import ... from
-# '@cypress/grep/src/support'`. @cypress/grep v5+ moved to dist/ with an
-# exports map that no longer exposes src/*, so with master-overlaid deps that
-# import cannot resolve. Rewrite it to the v5+/v6 `register` API (same line
-# master uses). No-op when the overlaid grep is v3/v4 or the import is already
-# new-style. Local checkouts (--dashboard-dir) are self-consistent and are
-# intentionally left untouched.
+# Release branches register grep with `import ... from '@cypress/grep/src/support'`.
+# v5+ moved to dist/ behind an exports map that no longer exposes src/*, so with
+# master overlaid dependencies that import cannot resolve. Rewrite it to the
+# v5+ `register` API, the same line master uses.
 #
-# Every exit path is either a rewrite or a hard failure. A silent no-op here
-# leaves tag filtering disabled at runtime, which looks like a green run that
-# quietly executed the wrong tests.
-- name: Adapt legacy @cypress/grep support import to v5+ overlay libs
-  ansible.builtin.shell: |
-    set -e
-    cd "{{ dashboard_dir }}"
-    SUPPORT_FILE="cypress/support/e2e.ts"
+# A silent no-op here leaves tag filtering disabled at runtime, which looks like
+# a green run that quietly executed the wrong tests. Every path therefore either
+# rewrites or asserts. Local checkouts are self consistent and are left alone.
+- name: Adapt the @cypress/grep registration to the overlaid version
+  when: dashboard_src is not defined
+  vars:
+    _support_file: "{{ dashboard_dir }}/cypress/support/e2e.ts"
+    _grep_spec: >-
+      {{ ((_grep_manifest.content | b64decode | from_json).dependencies | default({}))['@cypress/grep']
+         | default(((_grep_manifest.content | b64decode | from_json).devDependencies | default({}))['@cypress/grep'], true)
+         | default('', true) }}
+    _grep_major: "{{ _grep_spec | regex_search('[0-9]+') | default('', true) }}"
+    _support_text: "{{ _support_after.content | b64decode }}"
+    # v5+ can be bound by destructuring, by an aliased named import, or by the
+    # bare name. Take the first shape that matches.
+    _register_name: >-
+      {{ _support_text | regex_search('register:\s*([A-Za-z_][A-Za-z0-9_]*)', '\1') | default([], true) | first
+         | default(_support_text | regex_search('register\s+as\s+([A-Za-z_][A-Za-z0-9_]*)', '\1') | default([], true) | first, true)
+         | default('register' if _support_text is search('{[^}]*\bregister\b[^}]*}') else '', true) }}
+  block:
+    - name: Read the Cypress manifest for the grep version
+      ansible.builtin.slurp:
+        src: "{{ dashboard_dir }}/cypress/package.json"
+      register: _grep_manifest
 
-    [ -f cypress/package.json ] || { echo "[grep-compat] cypress/package.json not found, skipping"; exit 0; }
+    - name: Assert the manifest declares @cypress/grep
+      ansible.builtin.assert:
+        that: _grep_major | length > 0
+        success_msg: "@cypress/grep {{ _grep_spec }} declared"
+        fail_msg: >-
+          cypress/package.json declares no usable @cypress/grep version
+          (found '{{ _grep_spec }}'). The dependency overlay did not produce a
+          usable manifest and tag filtering would silently do nothing.
 
-    GREP_SPEC=$(sed -n 's/.*"@cypress\/grep"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' cypress/package.json | head -1)
-    if [ -z "${GREP_SPEC}" ]; then
-      echo "[grep-compat] ERROR: cypress/package.json declares no @cypress/grep dependency."
-      echo "[grep-compat] The overlay did not produce a usable manifest."
-      exit 1
-    fi
-    GREP_MAJOR=$(printf '%s' "${GREP_SPEC}" | sed -n 's/^[^0-9]*\([0-9][0-9]*\).*/\1/p')
-    if [ -z "${GREP_MAJOR}" ]; then
-      echo "[grep-compat] ERROR: cannot read a major version from @cypress/grep spec '${GREP_SPEC}'."
-      exit 1
-    fi
-    echo "[grep-compat] @cypress/grep spec=${GREP_SPEC}, major=${GREP_MAJOR}"
-
-    [ -f "${SUPPORT_FILE}" ] || { echo "[grep-compat] ${SUPPORT_FILE} not found, skipping"; exit 0; }
+    - name: Read the Cypress support file
+      ansible.builtin.slurp:
+        src: "{{ _support_file }}"
+      register: _support_before
 
     # Registration has to live in this file. If it moved, doing nothing here
     # would leave tag filtering silently disabled at runtime.
-    if ! grep -q "@cypress/grep" "${SUPPORT_FILE}"; then
-      echo "[grep-compat] ERROR: ${SUPPORT_FILE} does not reference @cypress/grep."
-      echo "[grep-compat] Registration has moved and tag filtering would do nothing."
-      grep -rn "@cypress/grep" cypress/support/ 2>/dev/null || true
-      exit 1
-    fi
+    - name: Assert the support file registers @cypress/grep
+      ansible.builtin.assert:
+        that: (_support_before.content | b64decode) is search('@cypress/grep')
+        success_msg: "{{ _support_file | basename }} references @cypress/grep"
+        fail_msg: >-
+          {{ _support_file }} does not reference @cypress/grep. Registration has
+          moved and tag filtering would do nothing.
 
-    if [ "${GREP_MAJOR}" -lt 5 ]; then
-      echo "[grep-compat] legacy src/support import is still valid for v${GREP_MAJOR}"
-      exit 0
-    fi
+    - name: Rewrite the legacy @cypress/grep import
+      ansible.builtin.replace:
+        path: "{{ _support_file }}"
+        regexp: '^import\s+([A-Za-z_][A-Za-z0-9_]*)\s+from\s+[''"]@cypress/grep/src/support[''"];?'
+        replace: 'const { register: \1 } = require(''@cypress/grep'');'
+      when: _grep_major | int >= 5
 
-    if grep -q "@cypress/grep/src/support" "${SUPPORT_FILE}"; then
-      sed -i "s|^import \([A-Za-z_][A-Za-z0-9_]*\) from ['\"]@cypress/grep/src/support['\"];*|const { register: \1 } = require('@cypress/grep');|" "${SUPPORT_FILE}"
-      if grep -q "@cypress/grep/src/support" "${SUPPORT_FILE}"; then
-        echo "[grep-compat] ERROR: a legacy @cypress/grep/src/support import remains after the rewrite."
-        echo "[grep-compat] The import style is not one this task knows how to convert."
-        grep -n "@cypress/grep" "${SUPPORT_FILE}"
-        exit 1
-      fi
-      echo "[grep-compat] rewrote the legacy import for @cypress/grep v${GREP_MAJOR}"
-    else
-      echo "[grep-compat] no legacy import found"
-    fi
+    - name: Read the Cypress support file back
+      ansible.builtin.slurp:
+        src: "{{ _support_file }}"
+      register: _support_after
 
-    # Post-condition. Whatever path was taken, the file must bind the v5+
-    # `register` export and call it. Anything else registers nothing.
-    REG_NAME=$(sed -n "s/.*register:[[:space:]]*\([A-Za-z_][A-Za-z0-9_]*\).*@cypress\/grep.*/\1/p" "${SUPPORT_FILE}" | head -1)
-    [ -n "${REG_NAME}" ] || REG_NAME=$(sed -n "s/.*register[[:space:]]*as[[:space:]]*\([A-Za-z_][A-Za-z0-9_]*\).*@cypress\/grep.*/\1/p" "${SUPPORT_FILE}" | head -1)
-    [ -n "${REG_NAME}" ] || REG_NAME=$(sed -n "s/.*{[^}]*[^A-Za-z0-9_]\{0,1\}\(register\)[^A-Za-z0-9_:][^}]*}.*@cypress\/grep.*/\1/p" "${SUPPORT_FILE}" | head -1)
-    if [ -z "${REG_NAME}" ]; then
-      echo "[grep-compat] ERROR: ${SUPPORT_FILE} does not bind the v5+ 'register' export."
-      grep -n "@cypress/grep" "${SUPPORT_FILE}"
-      exit 1
-    fi
-    if ! grep -qE "(^|[^A-Za-z0-9_.])${REG_NAME}\(" "${SUPPORT_FILE}"; then
-      echo "[grep-compat] ERROR: ${SUPPORT_FILE} binds '${REG_NAME}' but never calls it."
-      echo "[grep-compat] @cypress/grep would not register and tags would not filter."
-      exit 1
-    fi
-    echo "[grep-compat] verified ${REG_NAME}() registers @cypress/grep v${GREP_MAJOR}"
-  when: dashboard_src is not defined
-  register: _grep_compat
-  changed_when: "'rewrote the legacy import' in _grep_compat.stdout"
+    # Whatever path was taken, the file has to bind the register export and
+    # call it. Anything else registers nothing.
+    - name: Assert @cypress/grep is registered
+      ansible.builtin.assert:
+        that:
+          - _support_text is not search('@cypress/grep/src/support')
+          - _register_name | length > 0
+          - _support_text is search('(^|[^A-Za-z0-9_.])' ~ _register_name ~ '\(')
+        success_msg: "{{ _register_name }}() registers @cypress/grep {{ _grep_spec }}"
+        fail_msg: >-
+          {{ _support_file }} does not register @cypress/grep v{{ _grep_major }}
+          after the rewrite. It must bind the register export and call it,
+          otherwise tags would not filter. Current grep lines:
+          {{ _support_text.splitlines() | select('search', '@cypress/grep') | join(' / ') }}
+      when: _grep_major | int >= 5
 
 - name: Configure Rancher users and role bindings
   ansible.builtin.include_role:

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -376,81 +376,127 @@
       "{{ dashboard_dir }}"
   changed_when: true
 
-# The build output is only shown when the build fails, so a successful build
-# says nothing about what actually landed in the image. That silence is how a
-# BuildKit only COPY flag reached Jenkins unnoticed. These checks read the
+# The docker build output is only shown when the build fails, so a successful
+# build says nothing about what actually landed in the image. That silence is
+# how a BuildKit only COPY flag reached Jenkins unnoticed. These tasks read the
 # facts back out of the finished image.
-#
-# Only deterministic in-image facts fail the run. The live cluster call is
-# reported and never fatal, because reachability is already asserted earlier by
-# "Wait for import cluster API" and a second network check here would only add
-# a new way for a good build to fail.
-- name: Verify the built image
-  ansible.builtin.shell: |
-    set -eu
-    image="dashboard-test:{{ executor_tag }}"
-    want_cypress="{{ cypress_version }}"
-    need_kubeconfig="{{ 'yes' if (create_initial_clusters | bool) else 'no' }}"
-    fail=""
-
-    in_image() {
-      docker run --rm --entrypoint sh "$image" -c "$1" 2>/dev/null
-    }
-
-    # Cypress ships one binary per version under CYPRESS_CACHE_FOLDER, while
-    # the npm package is installed at container start from cypress/package.json.
-    # A mismatch makes Cypress re-download the binary on every run and fail
-    # outright on hosts with no access to download.cypress.io.
-    if in_image "test -d /root/.cache/Cypress/$want_cypress"; then
-      echo "[image] OK   cypress binary $want_cypress present"
-    else
-      have=$(in_image 'ls /root/.cache/Cypress' | tr '\n' ' ' || true)
-      echo "[image] FAIL cypress binary $want_cypress missing, image holds: $have"
-      fail=yes
-    fi
-
-    if in_image 'command -v kubectl' >/dev/null; then
-      kver=$(in_image 'kubectl version --client 2>/dev/null | head -1' || true)
-      echo "[image] OK   kubectl ${kver:-present}"
-    else
-      echo "[image] FAIL kubectl missing, the imported cluster spec pipes into kubectl apply"
-      fail=yes
-    fi
-
-    if [ "$need_kubeconfig" = no ]; then
-      echo "[image] SKIP kubeconfig, create_initial_clusters is false"
-    elif in_image 'test -f /root/.kube/config'; then
-      echo "[image] OK   kubeconfig $(in_image 'ls -l /root/.kube/config' || true)"
-      # Local runs start the container with --user, so a non-root user has to
-      # be able to read it. Jenkins runs as root and would never notice.
-      mode=$(in_image 'stat -c %a /root/.kube/config' || true)
-      case "$mode" in
-        *[4567]) echo "[image] OK   kubeconfig mode $mode is world readable" ;;
-        *) echo "[image] FAIL kubeconfig mode ${mode:-unreadable} blocks the non-root user used by local runs"
-           fail=yes ;;
-      esac
-      # Informational only. Reachability is already asserted by "Wait for
-      # import cluster API", so failing here would only add a way for a good
-      # build to break.
-      echo "[image] ---- kubectl get nodes from inside the image, informational ----"
-      in_image 'kubectl --request-timeout=20s get nodes -o wide 2>&1 | head -8' \
-        | sed 's/^/[image] /' || echo "[image] NOTE could not reach the imported cluster from the image"
-    else
-      echo "[image] FAIL /root/.kube/config missing while create_initial_clusters is true"
-      fail=yes
-    fi
-
-    if [ -n "$fail" ]; then
-      echo "[image] one or more image checks failed"
-      exit 1
-    fi
-    echo "[image] image verified"
-  register: _image_verify
+- name: Read the Cypress binaries baked into the image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - run
+      - --rm
+      - --entrypoint
+      - ls
+      - "dashboard-test:{{ executor_tag }}"
+      - /root/.cache/Cypress
+  register: _image_cypress
   changed_when: false
+  failed_when: false
 
-- name: Show image verification output
+- name: Read the kubectl version baked into the image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - run
+      - --rm
+      - --entrypoint
+      - kubectl
+      - "dashboard-test:{{ executor_tag }}"
+      - version
+      - --client
+  register: _image_kubectl
+  changed_when: false
+  failed_when: false
+
+- name: Read the kubeconfig mode inside the image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - run
+      - --rm
+      - --entrypoint
+      - stat
+      - "dashboard-test:{{ executor_tag }}"
+      - -c
+      - "%a %n"
+      - /root/.kube/config
+  register: _image_kubeconfig
+  changed_when: false
+  failed_when: false
+  when: create_initial_clusters | bool
+
+# The npm package is installed at container start from cypress/package.json,
+# while the binary is baked in at build time. A mismatch makes Cypress
+# re-download the binary on every run and fail outright on hosts with no
+# access to download.cypress.io.
+- name: Assert the image carries the expected Cypress binary
+  ansible.builtin.assert:
+    that: cypress_version in (_image_cypress.stdout_lines | default([]))
+    success_msg: "Cypress binary {{ cypress_version }} is present"
+    fail_msg: >-
+      The image was built for a different cypress_version. Wanted
+      {{ cypress_version }}, image holds
+      '{{ _image_cypress.stdout_lines | default([]) | join(', ') }}'.
+
+- name: Assert the image carries kubectl
+  ansible.builtin.assert:
+    that: _image_kubectl.rc == 0
+    success_msg: kubectl is present
+    fail_msg: >-
+      kubectl is missing from the image. The imported cluster spec pipes the
+      registration manifest into kubectl apply, so that test cannot pass.
+
+# Local runs start the container with --user, so a non-root user has to be able
+# to read the kubeconfig. Jenkins runs as root and would never notice a mode
+# that is too strict.
+- name: Assert the kubeconfig is present and readable
+  ansible.builtin.assert:
+    that:
+      - _image_kubeconfig.rc == 0
+      - _image_kubeconfig.stdout is search('^[0-7][0-7][4-7] ')
+    success_msg: the kubeconfig is present and world readable
+    fail_msg: >-
+      create_initial_clusters is true but /root/.kube/config is missing or is
+      not world readable. Local runs pass --user, so a non-root user has to be
+      able to read it.
+  when: create_initial_clusters | bool
+
+# Informational only. Reachability is already asserted by "Wait for import
+# cluster API", so failing again here would add a way for a good build to break.
+- name: Reach the imported cluster from inside the image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - run
+      - --rm
+      - --entrypoint
+      - kubectl
+      - "dashboard-test:{{ executor_tag }}"
+      - --request-timeout=20s
+      - get
+      - nodes
+      - -o
+      - wide
+  register: _image_cluster_reach
+  changed_when: false
+  failed_when: false
+  when: create_initial_clusters | bool
+
+- name: Show what the image verification found
   ansible.builtin.debug:
-    msg: "{{ _image_verify.stdout_lines }}"
+    msg: >-
+      cypress={{ _image_cypress.stdout_lines | default([]) | join(',') }}
+      kubectl={{ (_image_kubectl.stdout_lines | default([]) | join(' ')) | truncate(60) }}
+      kubeconfig={{ _image_kubeconfig.stdout | default('skipped') | trim }}
+
+- name: Show the imported cluster as the image sees it
+  ansible.builtin.debug:
+    msg: >-
+      {{ _image_cluster_reach.stdout_lines | default([])
+         | ternary(_image_cluster_reach.stdout_lines | default([]),
+                   ['could not reach the imported cluster from the image']) }}
+  when: create_initial_clusters | bool
 
 - name: Generate .env file
   ansible.builtin.template:

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -256,10 +256,11 @@
         regexp: "kubectl"
         state: absent
 
+    # Removes both the COPY of the kubeconfig and the chmod that follows it.
     - name: Strip imported_config from Dockerfile.ci
       ansible.builtin.lineinfile:
         path: "{{ dashboard_dir }}/cypress/jenkins/Dockerfile.ci"
-        regexp: "imported_config"
+        regexp: 'imported_config|/root/\.kube/config'
         state: absent
 
 - name: Set custom node key from SSH key file
@@ -307,6 +308,41 @@
         else 'The overlay from ' ~ (dashboard_overlay_branch | default('master', true)) ~ ' did not produce them.'
       }}
   changed_when: false
+
+- name: Reject BuildKit-only syntax in Dockerfile.ci
+  ansible.builtin.shell: |
+    set -e
+    if grep -nE '^[[:space:]]*(COPY|ADD)[[:space:]]+--(chmod|link|exclude)([[:space:]]|=)|^[[:space:]]*RUN[[:space:]]+--(mount|network|security)([[:space:]]|=)' \
+        "{{ dashboard_dir }}/cypress/jenkins/Dockerfile.ci"; then
+      echo "[verify] ERROR: the lines above use BuildKit-only Dockerfile syntax."
+      echo "[verify] Jenkins agents build with the legacy builder, which rejects it."
+      echo "[verify] Rewrite them so the image builds under both builders, for"
+      echo "[verify] example COPY followed by a separate RUN chmod."
+      exit 1
+    fi
+    echo "[verify] OK, Dockerfile.ci builds under the legacy builder"
+  changed_when: false
+
+# The image caches the Cypress binary named by cypress_version, while the npm
+# package comes from cypress/package.json at container start. When they differ
+# Cypress downloads the pinned binary on every run, which is slow and fails
+# outright on hosts without access to download.cypress.io.
+- name: Check cypress_version against the pinned Cypress
+  ansible.builtin.shell: |
+    set -e
+    pinned=$(sed -n 's/.*"cypress"[[:space:]]*:[[:space:]]*"[~^]\{0,1\}\([0-9][^"]*\)".*/\1/p' \
+      "{{ dashboard_dir }}/cypress/package.json" | head -1)
+    if [ -n "${pinned}" ] && [ "${pinned}" != "{{ cypress_version }}" ]; then
+      echo "WARNING: cypress_version is {{ cypress_version }} but cypress/package.json pins ${pinned}."
+      echo "Set cypress_version to ${pinned} in vars.yaml, or in VARS_YAML_CONFIG on the Jenkins job."
+    fi
+  register: _cypress_pin
+  changed_when: false
+
+- name: Warn when cypress_version does not match the pinned Cypress
+  ansible.builtin.debug:
+    msg: "{{ _cypress_pin.stdout_lines }}"
+  when: "'WARNING' in (_cypress_pin.stdout | default(''))"
 
 - name: Show Docker build args
   ansible.builtin.debug:

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -358,6 +358,34 @@
     - _pinned_cypress | length > 0
     - _pinned_cypress != cypress_version
 
+# cypress.sh and grep-filter.ts resolve these at run time inside the container.
+# grep-filter.ts requires globby and find-test-names unguarded, so a checkout
+# that lacks them exits 1 from a stack trace that names a module rather than
+# the cause. Name the gap here instead, while the log still has context.
+- name: Assert the checkout declares the packages the run needs
+  ansible.builtin.assert:
+    that: _missing_runtime_deps | length == 0
+    success_msg: "the checkout declares every package cypress.sh and grep-filter.ts load"
+    fail_msg: >-
+      This checkout does not declare {{ _missing_runtime_deps | join(', ') }}.
+      grep-filter.ts requires globby and find-test-names directly and exits 1
+      without them, and jrm cannot merge the JUnit XML, so the run would fail
+      or produce no report.
+      {{ 'The dependency overlay is skipped for local checkouts, so the directory passed to --dashboard-dir has to supply them.'
+         if dashboard_src is defined
+         else 'The overlay from ' ~ (dashboard_overlay_branch | default('master', true)) ~ ' did not supply them.' }}
+  vars:
+    _required_runtime_deps:
+      - cypress
+      - "@cypress/grep"
+      - cypress-mochawesome-reporter
+      - junit-report-merger
+      - find-test-names
+      - globby
+    _manifest: "{{ (_cypress_manifest.content | b64decode | from_json) if (_cypress_manifest.content | default('') | length) > 0 else {} }}"
+    _declared: "{{ ((_manifest.dependencies | default({})) | combine(_manifest.devDependencies | default({}))) | list }}"
+    _missing_runtime_deps: "{{ _required_runtime_deps | difference(_declared) }}"
+
 - name: Show Docker build args
   ansible.builtin.debug:
     msg: >-


### PR DESCRIPTION
Jenkins agents build with the legacy Docker builder, which rejects the BuildKit only `COPY --chmod` flag introduced in #135. Every Jenkins run has failed at the kubeconfig COPY step since that merged.

```
Step 9/10 : COPY --chmod=644 imported_config /root/.kube/config
the --chmod option requires BuildKit
```

## The fix

`COPY` followed by a separate `RUN chmod 644`. Both builders accept it and produce the same result. Mode 644 still matters because local runs start the container with `--user`.

## Everything else

Minor improvements and idiomatic adjustments, no behaviour change:

| Change | Why |
|---|---|
| Guard rejects BuildKit only syntax in `Dockerfile.ci` | Stops this class of breakage reaching Jenkins again |
| Verify the built image before running tests | The build output is only shown on failure, so a green build said nothing about what landed in the image |
| Kubeconfig strip also removes the `chmod` line | It was matching only the `COPY` |
| Warn when `cypress_version` differs from the manifest pin | A mismatch makes Cypress redownload the binary on every run |
| Name the missing package when reporting cannot run | `grep-filter.ts` exited from a bare module resolution trace |
| `shell` blocks replaced with `slurp`, `assert`, `replace`, `command` | Six shell tasks down to two. Each check is now a named task, and a failure prints the reason instead of the script |

## Verified on Jenkins

Six builds against the staging job, `dashboard_branch` covering master, release-2.13, release-2.14 and release-2.15, with `create_initial_clusters` both true and false.

- Zero BuildKit errors, image builds on every branch
- Both sides of every conditional exercised: kubeconfig strip, grep compatibility rewrite, dependency overlay, kubeconfig assert
- `kubectl get nodes` from inside the built image returns the imported cluster
- Master with `@generic` passes 53 of 53, unchanged from before

Release branch runs report UNSTABLE from a preexisting upstream issue: those branches still use the Cypress 11 `testIsolation: 'off'` string form, which Cypress 15 rejects at suite load. Unrelated to this change and present before it.
