### PR TITLE
[Dashboard] - Keep a release branch on the Cypress it pins

### DIFF
--- a/ansible/testing/dashboard-e2e/README.md
+++ b/ansible/testing/dashboard-e2e/README.md
@@ -381,9 +381,20 @@ This is useful when:
 > and `exitCode` from Cypress 15. Keeping your branch rebased on its upstream
 > avoids this.
 
-> **Note:** The setup stage copies a few CI files (`Dockerfile.ci`, `cypress.sh`,
-> etc.) into `cypress/jenkins/` in your checkout to build the test image. Clean
-> them with `git checkout -- cypress/jenkins/` if needed.
+> **Note:** The setup stage writes into your checkout to build the test image:
+> CI files in `cypress/jenkins/` (`Dockerfile.ci`, `cypress.sh`, and others),
+> `results.xml` and `cypress/jenkins/reports/` from the run, and with
+> `create_initial_clusters` an `imported_config` file holding the imported
+> cluster's kubeconfig. None are covered by dashboard's `.gitignore`, so clear
+> them before committing:
+>
+> ```bash
+> git checkout -- cypress/jenkins/
+> git clean -fd cypress/jenkins/ && rm -f imported_config results.xml
+> ```
+>
+> `./run.sh clean` does not touch them. It removes the wrapper's own artifacts
+> in this directory, the cloned checkout, `outputs/` and `.env`.
 
 ### Running a single spec file
 

--- a/ansible/testing/dashboard-e2e/README.md
+++ b/ansible/testing/dashboard-e2e/README.md
@@ -334,7 +334,7 @@ rancher_image_tag: "head"
 | `create_initial_clusters` | `true` | Whether to create import cluster and custom node. In `existing` mode, provisions only these resources (not the Rancher server) |
 | `dashboard_repo` | `rancher/dashboard` | Dashboard GitHub repo to clone |
 | `dashboard_branch` | (auto-detected) | Branch to clone. Auto-detected from `rancher_image_tag` (e.g. `v2.14-head` → `release-2.14`) |
-| `dashboard_overlay_branch` | `master` | Branch to overlay dependency files from (package.json, yarn.lock, cypress.config.ts). CI files come from the playbook's `files/` directory |
+| `dashboard_overlay_branch` | (resolved) | Branch to overlay dependency files from (package.json, yarn.lock, cypress.config.ts), for branches that carry no `cypress/package.json` of their own. Left unset, the nearest newer release branch pinning the same Cypress major is used, falling back to `master`. CI files always come from the playbook's `files/` directory |
 
 ### Using a local dashboard checkout
 
@@ -411,34 +411,51 @@ that is not prime/noVai. `@bypass` drops those exclusions too.
 ### Testing release branches (release-2.14, release-2.15, ...)
 
 Execution specs come from the target branch (auto-detected from
-`rancher_image_tag`, or set via `dashboard_branch`), while dependency files
-(`package.json`, `yarn.lock`, `cypress/package.json`, `cypress/yarn.lock`,
-`cypress.config.ts`) are overlaid from `dashboard_overlay_branch` (default
-`master`) and CI files come from this playbook's `files/` directory. Release
-branches therefore run with master's Cypress and library versions.
+`rancher_image_tag`, or set via `dashboard_branch`), and CI files come from this
+playbook's `files/` directory.
+
+Dependencies follow the branch rather than master. A checkout that carries its
+own `cypress/package.json` is self consistent, so it keeps its own dependency
+manifests and its own Cypress. That layout exists from `release-2.14` onwards.
+Older branches still get `package.json`, `yarn.lock`, `cypress/package.json`,
+`cypress/yarn.lock` and `cypress.config.ts` overlaid from another branch, chosen
+in this order:
+
+1. `dashboard_overlay_branch`, when set. An explicit value always wins.
+2. The nearest newer release branch, searched across the next three minors,
+   whose `cypress/package.json` pins the same Cypress major as the target's root
+   `package.json`. Nearest is closest in time to the target, so its spec set and
+   dependency surface have drifted least.
+3. `master`, which is what the playbook did before.
+
+`cypress_version` is then read from whichever `cypress/package.json` the
+checkout ends up with, so the binary baked into the image and the npm package
+yarn installs always agree. Any value passed in is overridden. Packages that
+`cypress.sh` and `grep-filter.ts` resolve at run time but the pinned manifest
+does not declare are installed inside the container at start.
 
 Cross-version compatibility is handled automatically:
 
 - master pins `@cypress/grep` v6, whose `exports` map removed the
-  `@cypress/grep/src/support` entrypoint that release-2.14/2.15 import in
+  `@cypress/grep/src/support` entrypoint that older branches import in
   `cypress/support/e2e.ts`. The setup stage rewrites that import to the
-  v5+/v6 `register` API when the overlaid `@cypress/grep` major is >= 5
-  (skipped with `--dashboard-dir`, where deps and specs are self-consistent).
+  v5+/v6 `register` API when the resolved `@cypress/grep` major is >= 5, so a
+  branch keeping its own v3/v4 grep is left alone.
 - `cypress.config.jenkins.ts` and `grep-filter.ts` (from `files/`) support
   both the v5+/v6 (`dist/`, exports map) and legacy v3/v4 (`src/`) layouts.
-- Config options removed after Cypress 11 (`experimentalSessionAndOrigin`,
-  `videoUploadOnPasses`) only produce warnings on Cypress 12+, not errors.
+- Cypress 11 will not accept a suite level `testIsolation` without
+  `experimentalSessionAndOrigin`, and Cypress 12 removed that option.
+  `cypress.config.jenkins.ts` sets it only when `@cypress/grep/plugin` does not
+  resolve, which is the same signal that says the checkout is on the old stack.
 
 Caveats:
 
-- Old specs run under master's Cypress binary (`cypress_version`). Specs that
-  depend on behavior changed since Cypress 11 need the full legacy stack
-  instead: set `dashboard_overlay_branch` to the release branch **and** pin the
-  matching `cypress_version` (for example `release-2.15` + `11.1.0`). With
-  target == overlay branch the overlay and the import rewrite are both skipped.
-- `cypress_version` has no playbook default and must match the overlay branch's
-  Cypress. In Jenkins, `VARS_YAML_CONFIG` must pin it accordingly
-  (`15.19.0` while master stays on Cypress 15.19.0).
+- The overlay search window is the next three minors. A branch further behind
+  than that falls back to master, which is the previous behaviour.
+- Specs are written against the Cypress version their branch pins. `cy.exec`
+  yields `code` up to Cypress 14 and `exitCode` from Cypress 15, so running a
+  branch under the wrong major breaks `cluster-manager.spec.ts` even when the
+  suite loads.
 
 ### Pinned versions
 

--- a/ansible/testing/dashboard-e2e/README.md
+++ b/ansible/testing/dashboard-e2e/README.md
@@ -371,6 +371,16 @@ This is useful when:
 > path instead, which overlays the dependency manifests from
 > `dashboard_overlay_branch`.
 
+> **Cypress version:** `cypress_version` is read from your checkout's
+> `cypress/package.json`, so you do not need to set it and any value you pass is
+> overridden. Nothing is overlaid onto a local checkout, which means the
+> manifests and the specs are whatever your branch has. If you branch off
+> `release-2.15` you get Cypress 11 and your specs must be written for it; if you
+> branch off `master` you get Cypress 15. Mixing the two breaks in ways the
+> playbook cannot detect, for example `cy.exec` yields `code` up to Cypress 14
+> and `exitCode` from Cypress 15. Keeping your branch rebased on its upstream
+> avoids this.
+
 > **Note:** The setup stage copies a few CI files (`Dockerfile.ci`, `cypress.sh`,
 > etc.) into `cypress/jenkins/` in your checkout to build the test image. Clean
 > them with `git checkout -- cypress/jenkins/` if needed.
@@ -407,6 +417,9 @@ With a positive tag such as `@adminUser`, only matching tests inside your spec
 run. To run everything in the spec, leave `cypress_tags` empty: tag adjustment
 then produces exclusion-only tags (`-@prime+-@noVai`), which match every test
 that is not prime/noVai. `@bypass` drops those exclusions too.
+
+`--spec` selects which file runs and nothing else. The Cypress version comes
+from the checkout, so it is the same whether you run one spec or all of them.
 
 ### Testing release branches (release-2.14, release-2.15, ...)
 

--- a/ansible/testing/dashboard-e2e/README.md
+++ b/ansible/testing/dashboard-e2e/README.md
@@ -324,6 +324,28 @@ rancher_image_tag: "head"
 # → latest chart in the repo, image rancher/rancher:head
 ```
 
+### The branch contract
+
+Everything version related is decided by one file in the dashboard checkout,
+`cypress/package.json`. It is to this playbook what `cluster_nodes_json` is to
+the Tofu to Ansible boundary: the single place a branch declares what it needs.
+
+| the playbook reads | and decides |
+|--------------------|-------------|
+| the file exists | whether the dependency overlay runs at all |
+| its `cypress` pin | `cypress_version`, so the baked binary and the installed package agree |
+| its `@cypress/grep` pin | whether the legacy `src/support` import is rewritten, and whether grep settings go through `expose` or `env` |
+| which of `_runtime_deps` it declares | what `cypress.sh` installs at container start |
+
+Two consequences follow. A branch that carries the file is self consistent and
+is left alone, which is every branch from `release-2.14` onwards. A branch that
+does not carry it has no contract to read, so one is borrowed from another
+branch, which is what the overlay does and why `release-2.13` needs it.
+
+Nothing else is inspected. Not the branch name, not `rancher_image_tag`, not
+anything you pass in `vars.yaml`. Editing this file by hand changes what the
+whole pipeline does.
+
 ### Cypress test runner
 
 | Variable | Default | Description |
@@ -371,15 +393,15 @@ This is useful when:
 > path instead, which overlays the dependency manifests from
 > `dashboard_overlay_branch`.
 
-> **Cypress version:** `cypress_version` is read from your checkout's
-> `cypress/package.json`, so you do not need to set it and any value you pass is
-> overridden. Nothing is overlaid onto a local checkout, which means the
-> manifests and the specs are whatever your branch has. If you branch off
-> `release-2.15` you get Cypress 11 and your specs must be written for it; if you
-> branch off `master` you get Cypress 15. Mixing the two breaks in ways the
-> playbook cannot detect, for example `cy.exec` yields `code` up to Cypress 14
-> and `exitCode` from Cypress 15. Keeping your branch rebased on its upstream
-> avoids this.
+> **Cypress version:** the checkout supplies its own [branch
+> contract](#the-branch-contract), so `cypress_version` is read from its
+> `cypress/package.json` and any value you pass is overridden. Nothing is
+> overlaid onto a local checkout, which means the manifests and the specs are
+> whatever your branch has. If you branch off `release-2.15` you get Cypress 11
+> and your specs must be written for it; if you branch off `master` you get
+> Cypress 15. Mixing the two breaks in ways the playbook cannot detect, for
+> example `cy.exec` yields `code` up to Cypress 14 and `exitCode` from Cypress
+> 15. Keeping your branch rebased on its upstream avoids this.
 
 > **Note:** The setup stage writes into your checkout to build the test image:
 > CI files in `cypress/jenkins/` (`Dockerfile.ci`, `cypress.sh`, and others),
@@ -439,11 +461,11 @@ Execution specs come from the target branch (auto-detected from
 playbook's `files/` directory.
 
 Dependencies follow the branch rather than master. A checkout that carries its
-own `cypress/package.json` is self consistent, so it keeps its own dependency
-manifests and its own Cypress. That layout exists from `release-2.14` onwards.
-Older branches still get `package.json`, `yarn.lock`, `cypress/package.json`,
-`cypress/yarn.lock` and `cypress.config.ts` overlaid from another branch, chosen
-in this order:
+own [branch contract](#the-branch-contract) is self consistent, so it keeps its
+own dependency manifests and its own Cypress. That layout exists from
+`release-2.14` onwards. Older branches have no contract to read, so
+`package.json`, `yarn.lock`, `cypress/package.json`, `cypress/yarn.lock` and
+`cypress.config.ts` are overlaid from another branch, chosen in this order:
 
 1. `dashboard_overlay_branch`, when set. An explicit value always wins.
 2. The nearest newer release branch, searched across the next three minors,
@@ -452,11 +474,8 @@ in this order:
    dependency surface have drifted least.
 3. `master`, which is what the playbook did before.
 
-`cypress_version` is then read from whichever `cypress/package.json` the
-checkout ends up with, so the binary baked into the image and the npm package
-yarn installs always agree. Any value passed in is overridden. Packages that
-`cypress.sh` and `grep-filter.ts` resolve at run time but the pinned manifest
-does not declare are installed inside the container at start.
+The contract is then read from whichever `cypress/package.json` the checkout
+ends up with.
 
 Cross-version compatibility is handled automatically:
 

--- a/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
+++ b/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
@@ -48,6 +48,21 @@
     # Executor-scoped image tag (prevents concurrent Jenkins builds from clobbering each other)
     executor_tag: "{{ lookup('env', 'EXECUTOR_NUMBER') | default('0', true) }}"
 
+    # Packages cypress.sh and grep-filter.ts load at run time inside the
+    # container. A checkout that keeps its own Cypress may predate some of
+    # them, so cypress.sh installs whichever are absent. Versions are exact:
+    # everything else in this pipeline is pinned, from the base image digest
+    # to yarn.lock, and this is the only install the repository owns.
+    _runtime_deps:
+      - { name: cypress, version: "" }
+      - { name: "@cypress/grep", version: "" }
+      - { name: cypress-mochawesome-reporter, version: 3.8.2 }
+      - { name: cypress-multi-reporters, version: 1.6.4 }
+      - { name: mocha-junit-reporter, version: 2.2.1 }
+      - { name: junit-report-merger, version: 9.0.3 }
+      - { name: find-test-names, version: 1.29.19 }
+      - { name: globby, version: 11.1.0 }
+
   pre_tasks:
     - name: Create outputs directory
       ansible.builtin.file:

--- a/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
+++ b/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
@@ -49,10 +49,9 @@
     executor_tag: "{{ lookup('env', 'EXECUTOR_NUMBER') | default('0', true) }}"
 
     # Packages cypress.sh and grep-filter.ts load at run time inside the
-    # container. A checkout that keeps its own Cypress may predate some of
-    # them, so cypress.sh installs whichever are absent. Versions are exact:
-    # everything else in this pipeline is pinned, from the base image digest
-    # to yarn.lock, and this is the only install the repository owns.
+    # container, installed only when the checkout does not declare them.
+    # Versions are exact because everything else here is pinned, from the base
+    # image digest to yarn.lock.
     _runtime_deps:
       - { name: cypress, version: "" }
       - { name: "@cypress/grep", version: "" }

--- a/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
+++ b/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'cypress';
 import { removeDirectory } from 'cypress-delete-downloads-folder';
 import websocketTasks from '../../cypress/support/utils/webSocket-utils';
 import path from 'path';
+import * as os from 'os';
 
 // Required for env vars to be available in cypress
 require('dotenv').config();
@@ -26,6 +27,22 @@ const baseUrl = (process.env.TEST_BASE_URL || 'https://localhost:8005').replace(
 const DEFAULT_USERNAME = 'admin';
 const username = process.env.TEST_USERNAME || DEFAULT_USERNAME;
 const apiUrl = process.env.API || (baseUrl.endsWith('/dashboard') ? baseUrl.split('/').slice(0, -1).join('/') : baseUrl);
+
+/**
+ * Share of a single core this process used over a short sample window,
+ * reported the same way dashboard's own base-config.ts reports it.
+ */
+const sampleCpuPercent = (sampleMs = 100): Promise<number> => new Promise((resolve) => {
+  const startUsage = process.cpuUsage();
+  const startTime = Date.now();
+
+  setTimeout(() => {
+    const usage = process.cpuUsage(startUsage);
+    const elapsedMicroseconds = (Date.now() - startTime) * 1000;
+
+    resolve((usage.user + usage.system) / elapsedMicroseconds * 100);
+  }, sampleMs);
+});
 
 /**
  * LOGS:
@@ -259,7 +276,26 @@ export default defineConfig({
         require('../../cypress/support/plugins/accessibility').default(on, config);
       }
 
-      on('task', { removeDirectory });
+      // cypress/support/e2e.ts calls this task from a shared afterEach whenever a
+      // test fails. An unhandled task throws inside the hook, and Cypress skips
+      // every remaining test in the spec, so one failure costs the whole file.
+      // dashboard master guards the call behind Cypress.env('hasHostStats'),
+      // which only its own base-config.ts sets, but the branches that predate
+      // that guard call the task unconditionally. Registering it here keeps the
+      // hook harmless on every branch.
+      on('task', {
+        removeDirectory,
+        getHostStats: async() => {
+          const totalMem = os.totalmem();
+          const usedMem = totalMem - os.freemem();
+
+          return {
+            memory:     `${ (usedMem / 1024 / 1024).toFixed(2) }MB (${ (usedMem / totalMem * 100).toFixed(2) }%)`,
+            processCpu: `${ (await sampleCpuPercent()).toFixed(2) }%`
+          };
+        }
+      });
+      config.env.hasHostStats = true;
       websocketTasks(on, config);
 
       require('cypress-terminal-report/src/installLogsPrinter')(on, {

--- a/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
+++ b/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
@@ -275,7 +275,10 @@ export default defineConfig({
       return config;
     },
     fixturesFolder:               'cypress/e2e/blueprints',
-    experimentalSessionAndOrigin: true,
+    // Cypress 11 will not accept a suite level testIsolation without this,
+    // and Cypress 12 removed it, so 15 prints a removal notice on every run.
+    // grep v5+ resolving means the checkout is on Cypress 15.
+    ...(grepUsesExpose ? {} : { experimentalSessionAndOrigin: true }),
     specPattern:                  testDirs,
     baseUrl
   },

--- a/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
+++ b/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
@@ -279,10 +279,13 @@ export default defineConfig({
       // cypress/support/e2e.ts calls this task from a shared afterEach whenever a
       // test fails. An unhandled task throws inside the hook, and Cypress skips
       // every remaining test in the spec, so one failure costs the whole file.
+      //
       // dashboard master guards the call behind Cypress.env('hasHostStats'),
-      // which only its own base-config.ts sets, but the branches that predate
-      // that guard call the task unconditionally. Registering it here keeps the
-      // hook harmless on every branch.
+      // which only its own base-config.ts sets, so master skips it here. The
+      // branches that predate that guard call the task unconditionally and need
+      // it registered. Deliberately leave the flag unset: registering the task
+      // is what those branches need, and setting the flag would instead start
+      // running a hook on master that has never run under this config.
       on('task', {
         removeDirectory,
         getHostStats: async() => {
@@ -295,7 +298,6 @@ export default defineConfig({
           };
         }
       });
-      config.env.hasHostStats = true;
       websocketTasks(on, config);
 
       require('cypress-terminal-report/src/installLogsPrinter')(on, {

--- a/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
+++ b/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
@@ -282,7 +282,6 @@ export default defineConfig({
     specPattern:                  testDirs,
     baseUrl
   },
-  video:               false,
-  videoCompression:    25,
-  videoUploadOnPasses: false,
+  video:            false,
+  videoCompression: 25,
 });

--- a/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
+++ b/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
@@ -29,8 +29,8 @@ const username = process.env.TEST_USERNAME || DEFAULT_USERNAME;
 const apiUrl = process.env.API || (baseUrl.endsWith('/dashboard') ? baseUrl.split('/').slice(0, -1).join('/') : baseUrl);
 
 /**
- * Share of a single core this process used over a short sample window,
- * reported the same way dashboard's own base-config.ts reports it.
+ * Share of a single core used over a short window, matching how dashboard's
+ * own base-config.ts reports it.
  */
 const sampleCpuPercent = (sampleMs = 100): Promise<number> => new Promise((resolve) => {
   const startUsage = process.cpuUsage();
@@ -276,16 +276,10 @@ export default defineConfig({
         require('../../cypress/support/plugins/accessibility').default(on, config);
       }
 
-      // cypress/support/e2e.ts calls this task from a shared afterEach whenever a
-      // test fails. An unhandled task throws inside the hook, and Cypress skips
-      // every remaining test in the spec, so one failure costs the whole file.
-      //
-      // dashboard master guards the call behind Cypress.env('hasHostStats'),
-      // which only its own base-config.ts sets, so master skips it here. The
-      // branches that predate that guard call the task unconditionally and need
-      // it registered. Deliberately leave the flag unset: registering the task
-      // is what those branches need, and setting the flag would instead start
-      // running a hook on master that has never run under this config.
+      // Older branches call this task from a shared afterEach on failure. An
+      // unhandled task throws in the hook and skips the rest of the spec.
+      // master guards the call behind Cypress.env('hasHostStats'), so leaving
+      // that flag unset keeps master on the path it already takes.
       on('task', {
         removeDirectory,
         getHostStats: async() => {
@@ -313,9 +307,8 @@ export default defineConfig({
       return config;
     },
     fixturesFolder:               'cypress/e2e/blueprints',
-    // Cypress 11 will not accept a suite level testIsolation without this,
-    // and Cypress 12 removed it, so 15 prints a removal notice on every run.
-    // grep v5+ resolving means the checkout is on Cypress 15.
+    // Cypress 11 needs this to accept a suite level testIsolation. Cypress 12
+    // removed it. grep v5+ resolving means the checkout is on Cypress 15.
     ...(grepUsesExpose ? {} : { experimentalSessionAndOrigin: true }),
     specPattern:                  testDirs,
     baseUrl

--- a/ansible/testing/dashboard-e2e/files/cypress.sh
+++ b/ansible/testing/dashboard-e2e/files/cypress.sh
@@ -19,14 +19,13 @@ if ! (cd cypress && NODE_NO_WARNINGS=1 yarn install --frozen-lockfile --silent);
 	exit 1
 fi
 # Packages this checkout does not declare, at versions pinned by the playbook.
-# A checkout that keeps its own Cypress can predate them, and grep-filter.ts
-# requires globby and find-test-names directly, so it exits 1 without them.
+# grep-filter.ts requires globby and find-test-names directly and exits 1
+# without them.
 if [ -n "${MISSING_RUNTIME_DEPS:-}" ]; then
 echo "[cypress.sh] Installing packages this checkout does not declare: ${MISSING_RUNTIME_DEPS}"
-# --no-lockfile because the lockfile belongs to the checkout and these are
-# additions on top of it, not a change to what it pins. The variable is
-# deliberately unquoted: it is a space separated list of name@version pairs
-# that has to split into separate arguments.
+# --no-lockfile because these are additions on top of the checkout's lockfile,
+# not a change to what it pins. Unquoted on purpose: a space separated list of
+# name@version pairs that has to split into separate arguments.
 # shellcheck disable=SC2086
 if ! (cd cypress && NODE_NO_WARNINGS=1 yarn add --no-lockfile --silent ${MISSING_RUNTIME_DEPS}); then
 echo "[cypress.sh] ERROR: could not install ${MISSING_RUNTIME_DEPS}"

--- a/ansible/testing/dashboard-e2e/files/cypress.sh
+++ b/ansible/testing/dashboard-e2e/files/cypress.sh
@@ -18,6 +18,23 @@ if ! (cd cypress && NODE_NO_WARNINGS=1 yarn install --frozen-lockfile --silent);
 	echo "[cypress.sh] yarn.lock exists: $(test -f cypress/yarn.lock && echo yes || echo no)"
 	exit 1
 fi
+# Packages this checkout does not declare, at versions pinned by the playbook.
+# A checkout that keeps its own Cypress can predate them, and grep-filter.ts
+# requires globby and find-test-names directly, so it exits 1 without them.
+if [ -n "${MISSING_RUNTIME_DEPS:-}" ]; then
+echo "[cypress.sh] Installing packages this checkout does not declare: ${MISSING_RUNTIME_DEPS}"
+# --no-lockfile because the lockfile belongs to the checkout and these are
+# additions on top of it, not a change to what it pins. The variable is
+# deliberately unquoted: it is a space separated list of name@version pairs
+# that has to split into separate arguments.
+# shellcheck disable=SC2086
+if ! (cd cypress && NODE_NO_WARNINGS=1 yarn add --no-lockfile --silent ${MISSING_RUNTIME_DEPS}); then
+echo "[cypress.sh] ERROR: could not install ${MISSING_RUNTIME_DEPS}"
+echo "[cypress.sh] Tag filtering and JUnit reporting both need these."
+exit 1
+fi
+fi
+
 # Point ./node_modules at the test dependencies. -n stops ln from following an
 # existing symlink and leaving a dangling link inside its target on repeat
 # --dashboard-dir runs. A real directory is left alone: that is a developer's

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -119,36 +119,29 @@
     - not _branch_manifest.stat.exists
     - dashboard_overlay_branch is not defined
 
-- name: Find an overlay source pinning the same Cypress major
-  ansible.builtin.shell: |
-    set -eu
-    cd {{ dashboard_dir }}
-    want="{{ _root_cypress_major | trim }}"
-    if [ -z "${want}" ]; then
-      echo "[overlay] root manifest names no Cypress version, falling back to master" >&2
-      echo master
-      exit 0
-    fi
-    for candidate in {{ _overlay_candidates | join(' ') }}; do
-      git fetch --depth=1 --quiet origin "${candidate}" 2>/dev/null || continue
-      manifest=$(git cat-file -p "FETCH_HEAD:cypress/package.json" 2>/dev/null) || continue
-      major=$(printf '%s' "${manifest}" | sed -n 's/.*"cypress"[[:space:]]*:[[:space:]]*"[~^]\{0,1\}\([0-9][0-9]*\).*/\1/p' | head -1)
-      if [ -n "${major}" ] && [ "${major}" = "${want}" ]; then
-        echo "${candidate}"
-        exit 0
-      fi
-      echo "[overlay] ${candidate} pins Cypress ${major:-unknown}, wanted ${want}" >&2
-    done
-    echo master
-  vars:
-    _root: "{{ (_root_manifest.content | b64decode | from_json) if (_root_manifest.content | default('') | length) > 0 else {} }}"
+- name: Read the Cypress major the checkout was written against
+  ansible.builtin.set_fact:
     _root_cypress_major: >-
       {{ ((_root.dependencies | default({})).cypress
           | default((_root.devDependencies | default({})).cypress, true)
           | default('', true) | regex_replace('^[~^]', '')).split('.')[0] }}
-    # release-2.13 yields base 2, minor 13, so the candidates are the next
-    # three minors. A target that is not a release branch yields no candidates
-    # and the probe falls through to master.
+  vars:
+    _root: "{{ (_root_manifest.content | b64decode | from_json) if (_root_manifest.content | default('') | length) > 0 else {} }}"
+  when:
+    - dashboard_src is not defined
+    - not _branch_manifest.stat.exists
+    - dashboard_overlay_branch is not defined
+
+- name: Read the candidate manifests
+  ansible.builtin.uri:
+    url: "https://raw.githubusercontent.com/{{ dashboard_repo | regex_replace('\\.git$', '') }}/{{ item }}/cypress/package.json"
+    return_content: true
+    status_code: [200, 404]
+  register: _candidate_manifests
+  vars:
+    # release-2.13 yields base 2 and minor 13, so the candidates are the next
+    # three minors. A target that is not a release branch yields none and the
+    # search falls through to master.
     _base: "{{ target_branch | regex_replace('^release-([0-9]+)[.]([0-9]+)$', '\\1') }}"
     _minor: "{{ target_branch | regex_replace('^release-([0-9]+)[.]([0-9]+)$', '\\2') }}"
     _overlay_candidates: >-
@@ -156,17 +149,35 @@
           'release-' ~ _base ~ '.' ~ (_minor | int + 2),
           'release-' ~ _base ~ '.' ~ (_minor | int + 3)]
          if _minor is match('^[0-9]+$') else [] }}
-  register: _overlay_probe
+  loop: "{{ _overlay_candidates }}"
+  loop_control:
+    label: "{{ item }}"
   changed_when: false
   when:
     - dashboard_src is not defined
     - not _branch_manifest.stat.exists
     - dashboard_overlay_branch is not defined
+    - _root_cypress_major | length > 0
 
+# The first candidate whose manifest pins the same Cypress major wins. Falling
+# back to master keeps the previous behaviour when none matches.
 - name: Set the overlay source
   ansible.builtin.set_fact:
-    _overlay_source: "{{ dashboard_overlay_branch | default(_overlay_probe.stdout | default('master', true) | trim, true) }}"
+    _overlay_source: "{{ dashboard_overlay_branch | default(_matching | default([]) | first | default('master', true), true) }}"
+  vars:
+    _matching: >-
+      {{ _candidate_manifests.results | default([])
+         | selectattr('status', 'eq', 200)
+         | selectattr('content', 'search', '"cypress"\s*:\s*"[~^]?' ~ _root_cypress_major ~ '[.]')
+         | map(attribute='item') | list }}
   when: dashboard_src is not defined
+
+- name: Report the overlay source
+  ansible.builtin.debug:
+    msg: "{{ target_branch }} pins Cypress {{ _root_cypress_major }}, overlaying from {{ _overlay_source }}"
+  when:
+    - dashboard_src is not defined
+    - not _branch_manifest.stat.exists
 
 - name: Overlay dependency files from dashboard master onto release branches
   ansible.builtin.shell: |

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -176,7 +176,16 @@
 
 - name: Report the overlay source
   ansible.builtin.debug:
-    msg: "{{ target_branch }} pins Cypress {{ _root_cypress_major }}, overlaying from {{ _overlay_source }}"
+    msg: "{{ _reason }}, overlaying from {{ _overlay_source }}"
+  vars:
+    _reason: >-
+      {%- if dashboard_overlay_branch is defined and dashboard_overlay_branch -%}
+        dashboard_overlay_branch names the source for {{ target_branch }}
+      {%- elif _root_cypress_major | default('') | length > 0 -%}
+        {{ target_branch }} pins Cypress {{ _root_cypress_major }}
+      {%- else -%}
+        {{ target_branch }} names no Cypress version in its root manifest
+      {%- endif -%}
   when:
     - dashboard_src is not defined
     - not _branch_manifest.stat.exists

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -159,8 +159,10 @@
     - dashboard_overlay_branch is not defined
     - _root_cypress_major | length > 0
 
-# The first candidate whose manifest pins the same Cypress major wins. Falling
-# back to master keeps the previous behaviour when none matches.
+# The candidates are in ascending order, so the first match is the nearest
+# newer branch. Nearest is what we want: it is closest in time to the target,
+# so its spec set and dependency surface have drifted least. Falling back to
+# master keeps the previous behaviour when none matches.
 - name: Set the overlay source
   ansible.builtin.set_fact:
     _overlay_source: "{{ dashboard_overlay_branch | default(_matching | default([]) | first | default('master', true), true) }}"

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -92,6 +92,18 @@
   loop_control:
     label: "{{ item.dest }}"
 
+# A checkout that carries its own cypress/package.json is self consistent and
+# keeps its own Cypress. Overlaying master's manifests onto it forces a Cypress
+# major the branch's specs were never written for, and the mismatch surfaces as
+# a suite that fails to load rather than as a version conflict. This is the
+# rule run.sh already applies to --dashboard-dir, so both modes now agree.
+# Branches that predate the split manifest still get the overlay.
+- name: Stat the checkout's own Cypress manifest
+  ansible.builtin.stat:
+    path: "{{ dashboard_dir }}/cypress/package.json"
+  register: _branch_manifest
+  when: dashboard_src is not defined
+
 - name: Overlay dependency files from dashboard master onto release branches
   ansible.builtin.shell: |
     set -e
@@ -114,6 +126,7 @@
   when:
     - dashboard_src is not defined
     - target_branch != (dashboard_overlay_branch | default('master', true))
+    - not _branch_manifest.stat.exists
   changed_when: true
 
 # Release branches register grep with `import ... from '@cypress/grep/src/support'`.
@@ -338,17 +351,14 @@
     src: "{{ dashboard_dir }}/cypress/package.json"
   register: _cypress_manifest
 
-# The image bakes the binary named by cypress_version, while the npm package
-# comes from this manifest at container start. When they differ Cypress
-# downloads the pinned binary on every run, and fails outright on hosts with no
-# access to download.cypress.io.
-- name: Warn when cypress_version does not match the pinned Cypress
-  ansible.builtin.debug:
-    msg: >-
-      WARNING: cypress_version is {{ cypress_version }} but
-      cypress/package.json pins {{ _pinned_cypress }}. Set cypress_version to
-      {{ _pinned_cypress }} in vars.yaml, or in VARS_YAML_CONFIG on the Jenkins
-      job.
+# The image bakes the binary named by cypress_version while the npm package is
+# installed from this manifest at container start. They have to agree: a
+# mismatch makes Cypress redownload the binary on every run and fail outright
+# on hosts with no access to download.cypress.io. The manifest wins because it
+# is what yarn will actually install.
+- name: Use the Cypress version the checkout installs
+  ansible.builtin.set_fact:
+    cypress_version: "{{ _pinned_cypress }}"
   vars:
     _pinned_cypress: >-
       {{ ((_cypress_manifest.content | b64decode | from_json).dependencies | default({})).cypress
@@ -358,33 +368,50 @@
     - _pinned_cypress | length > 0
     - _pinned_cypress != cypress_version
 
+- name: Report the Cypress version in use
+  ansible.builtin.debug:
+    msg: "Cypress {{ cypress_version }} for {{ target_branch | default('the local checkout', true) }}"
+
 # cypress.sh and grep-filter.ts resolve these at run time inside the container.
-# grep-filter.ts requires globby and find-test-names unguarded, so a checkout
-# that lacks them exits 1 from a stack trace that names a module rather than
-# the cause. Name the gap here instead, while the log still has context.
-- name: Assert the checkout declares the packages the run needs
+# A checkout that keeps its own Cypress may predate some of them, so name the
+# gap here and let cypress.sh install the pinned versions rather than failing a
+# run that can still produce results.
+- name: Read what the checkout declares
+  ansible.builtin.set_fact:
+    _declared: "{{ _decl }}"
+    _missing_runtime_deps: "{{ _runtime_deps | rejectattr('name', 'in', _decl) | map(attribute='name') | list }}"
+    # Only packages with a pinned version can be installed. cypress and
+    # @cypress/grep carry no version here because their major has to match the
+    # checkout, so a missing one is a hard failure rather than an install.
+    _missing_deps_pinned: >-
+      {{ _runtime_deps | rejectattr('name', 'in', _decl) | rejectattr('version', 'eq', '')
+         | map(attribute='name') | zip(_runtime_deps | rejectattr('name', 'in', _decl)
+         | rejectattr('version', 'eq', '') | map(attribute='version'))
+         | map('join', '@') | join(' ') }}
+  vars:
+    _m: "{{ (_cypress_manifest.content | b64decode | from_json) if (_cypress_manifest.content | default('') | length) > 0 else {} }}"
+    _decl: "{{ ((_m.dependencies | default({})) | combine(_m.devDependencies | default({}))) | list }}"
+
+- name: Report packages the checkout does not declare
+  ansible.builtin.debug:
+    msg: >-
+      {{ target_branch | default('the local checkout', true) }} does not declare
+      {{ _missing_runtime_deps | join(', ') }}. cypress.sh installs the pinned
+      versions at container start. grep-filter.ts requires globby and
+      find-test-names directly and exits 1 without them, and jrm cannot merge
+      the JUnit XML.
+  when: _missing_runtime_deps | length > 0
+
+- name: Assert the checkout can run Cypress at all
   ansible.builtin.assert:
-    that: _missing_runtime_deps | length == 0
-    success_msg: "the checkout declares every package cypress.sh and grep-filter.ts load"
+    that: "'cypress' in _declared and '@cypress/grep' in _declared"
+    success_msg: "the checkout declares cypress and @cypress/grep"
     fail_msg: >-
-      This checkout does not declare {{ _missing_runtime_deps | join(', ') }}.
-      grep-filter.ts requires globby and find-test-names directly and exits 1
-      without them, and jrm cannot merge the JUnit XML, so the run would fail
-      or produce no report.
+      This checkout declares no cypress or no @cypress/grep, so there is
+      nothing to run and no way to filter by tag.
       {{ 'The dependency overlay is skipped for local checkouts, so the directory passed to --dashboard-dir has to supply them.'
          if dashboard_src is defined
          else 'The overlay from ' ~ (dashboard_overlay_branch | default('master', true)) ~ ' did not supply them.' }}
-  vars:
-    _required_runtime_deps:
-      - cypress
-      - "@cypress/grep"
-      - cypress-mochawesome-reporter
-      - junit-report-merger
-      - find-test-names
-      - globby
-    _manifest: "{{ (_cypress_manifest.content | b64decode | from_json) if (_cypress_manifest.content | default('') | length) > 0 else {} }}"
-    _declared: "{{ ((_manifest.dependencies | default({})) | combine(_manifest.devDependencies | default({}))) | list }}"
-    _missing_runtime_deps: "{{ _required_runtime_deps | difference(_declared) }}"
 
 - name: Show Docker build args
   ansible.builtin.debug:

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -104,11 +104,75 @@
   register: _branch_manifest
   when: dashboard_src is not defined
 
+# A checkout without its own manifest still needs one, but master's pins the
+# Cypress major master was cut for, which may not be this branch's. Its root
+# manifest names the Cypress it was written against, so prefer the nearest
+# newer release branch that ships a split manifest pinning the same major.
+# Falling back to master keeps the previous behaviour when no such branch
+# exists, and an explicit dashboard_overlay_branch always wins.
+- name: Read the checkout's root manifest
+  ansible.builtin.slurp:
+    src: "{{ dashboard_dir }}/package.json"
+  register: _root_manifest
+  when:
+    - dashboard_src is not defined
+    - not _branch_manifest.stat.exists
+    - dashboard_overlay_branch is not defined
+
+- name: Find an overlay source pinning the same Cypress major
+  ansible.builtin.shell: |
+    set -eu
+    cd {{ dashboard_dir }}
+    want="{{ _root_cypress_major | trim }}"
+    if [ -z "${want}" ]; then
+      echo "[overlay] root manifest names no Cypress version, falling back to master" >&2
+      echo master
+      exit 0
+    fi
+    for candidate in {{ _overlay_candidates | join(' ') }}; do
+      git fetch --depth=1 --quiet origin "${candidate}" 2>/dev/null || continue
+      manifest=$(git cat-file -p "FETCH_HEAD:cypress/package.json" 2>/dev/null) || continue
+      major=$(printf '%s' "${manifest}" | sed -n 's/.*"cypress"[[:space:]]*:[[:space:]]*"[~^]\{0,1\}\([0-9][0-9]*\).*/\1/p' | head -1)
+      if [ -n "${major}" ] && [ "${major}" = "${want}" ]; then
+        echo "${candidate}"
+        exit 0
+      fi
+      echo "[overlay] ${candidate} pins Cypress ${major:-unknown}, wanted ${want}" >&2
+    done
+    echo master
+  vars:
+    _root: "{{ (_root_manifest.content | b64decode | from_json) if (_root_manifest.content | default('') | length) > 0 else {} }}"
+    _root_cypress_major: >-
+      {{ ((_root.dependencies | default({})).cypress
+          | default((_root.devDependencies | default({})).cypress, true)
+          | default('', true) | regex_replace('^[~^]', '')).split('.')[0] }}
+    # release-2.13 yields base 2, minor 13, so the candidates are the next
+    # three minors. A target that is not a release branch yields no candidates
+    # and the probe falls through to master.
+    _base: "{{ target_branch | regex_replace('^release-([0-9]+)[.]([0-9]+)$', '\\1') }}"
+    _minor: "{{ target_branch | regex_replace('^release-([0-9]+)[.]([0-9]+)$', '\\2') }}"
+    _overlay_candidates: >-
+      {{ ['release-' ~ _base ~ '.' ~ (_minor | int + 1),
+          'release-' ~ _base ~ '.' ~ (_minor | int + 2),
+          'release-' ~ _base ~ '.' ~ (_minor | int + 3)]
+         if _minor is match('^[0-9]+$') else [] }}
+  register: _overlay_probe
+  changed_when: false
+  when:
+    - dashboard_src is not defined
+    - not _branch_manifest.stat.exists
+    - dashboard_overlay_branch is not defined
+
+- name: Set the overlay source
+  ansible.builtin.set_fact:
+    _overlay_source: "{{ dashboard_overlay_branch | default(_overlay_probe.stdout | default('master', true) | trim, true) }}"
+  when: dashboard_src is not defined
+
 - name: Overlay dependency files from dashboard master onto release branches
   ansible.builtin.shell: |
     set -e
     cd {{ dashboard_dir }}
-    OVERLAY_BRANCH="{{ dashboard_overlay_branch | default('master', true) }}"
+    OVERLAY_BRANCH="{{ _overlay_source }}"
     echo "[overlay] target_branch={{ target_branch }}, overlay_from=${OVERLAY_BRANCH}"
     git fetch --depth=1 origin "${OVERLAY_BRANCH}" || {
       echo "[overlay] ERROR: git fetch origin ${OVERLAY_BRANCH} failed"
@@ -125,7 +189,7 @@
     echo "[overlay] OK, overlaid dependency files from ${OVERLAY_BRANCH} onto {{ target_branch }}"
   when:
     - dashboard_src is not defined
-    - target_branch != (dashboard_overlay_branch | default('master', true))
+    - target_branch != _overlay_source
     - not _branch_manifest.stat.exists
   changed_when: true
 

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -94,22 +94,18 @@
 
 # A checkout that carries its own cypress/package.json is self consistent and
 # keeps its own Cypress. Overlaying master's manifests onto it forces a Cypress
-# major the branch's specs were never written for, and the mismatch surfaces as
-# a suite that fails to load rather than as a version conflict. This is the
-# rule run.sh already applies to --dashboard-dir, so both modes now agree.
-# Branches that predate the split manifest still get the overlay.
+# major the branch's specs were never written for, which surfaces as a suite
+# that fails to load. run.sh already applies this rule to --dashboard-dir.
 - name: Stat the checkout's own Cypress manifest
   ansible.builtin.stat:
     path: "{{ dashboard_dir }}/cypress/package.json"
   register: _branch_manifest
   when: dashboard_src is not defined
 
-# A checkout without its own manifest still needs one, but master's pins the
-# Cypress major master was cut for, which may not be this branch's. Its root
-# manifest names the Cypress it was written against, so prefer the nearest
-# newer release branch that ships a split manifest pinning the same major.
-# Falling back to master keeps the previous behaviour when no such branch
-# exists, and an explicit dashboard_overlay_branch always wins.
+# A checkout without its own manifest still needs one. Its root manifest names
+# the Cypress it was written against, so prefer the nearest newer release
+# branch pinning the same major. An explicit dashboard_overlay_branch wins, and
+# master is the fallback, which is the previous behaviour.
 - name: Read the checkout's root manifest
   ansible.builtin.slurp:
     src: "{{ dashboard_dir }}/package.json"
@@ -160,9 +156,7 @@
     - _root_cypress_major | length > 0
 
 # The candidates are in ascending order, so the first match is the nearest
-# newer branch. Nearest is what we want: it is closest in time to the target,
-# so its spec set and dependency surface have drifted least. Falling back to
-# master keeps the previous behaviour when none matches.
+# newer branch, the one whose spec set has drifted least from the target.
 - name: Set the overlay source
   ansible.builtin.set_fact:
     _overlay_source: "{{ dashboard_overlay_branch | default(_matching | default([]) | first | default('master', true), true) }}"
@@ -437,11 +431,10 @@
     src: "{{ dashboard_dir }}/cypress/package.json"
   register: _cypress_manifest
 
-# The image bakes the binary named by cypress_version while the npm package is
-# installed from this manifest at container start. They have to agree: a
-# mismatch makes Cypress redownload the binary on every run and fail outright
-# on hosts with no access to download.cypress.io. The manifest wins because it
-# is what yarn will actually install.
+# The image bakes the binary named by cypress_version, while yarn installs the
+# npm package from this manifest at container start. A mismatch makes Cypress
+# redownload the binary every run, and fail outright where download.cypress.io
+# is unreachable. The manifest wins because it is what yarn actually installs.
 - name: Use the Cypress version the checkout installs
   ansible.builtin.set_fact:
     cypress_version: "{{ _pinned_cypress }}"
@@ -459,16 +452,14 @@
     msg: "Cypress {{ cypress_version }} for {{ target_branch | default('the local checkout', true) }}"
 
 # cypress.sh and grep-filter.ts resolve these at run time inside the container.
-# A checkout that keeps its own Cypress may predate some of them, so name the
-# gap here and let cypress.sh install the pinned versions rather than failing a
-# run that can still produce results.
+# A checkout that keeps its own Cypress may predate some, so name the gap and
+# let cypress.sh install them rather than fail a run that can still report.
 - name: Read what the checkout declares
   ansible.builtin.set_fact:
     _declared: "{{ _decl }}"
     _missing_runtime_deps: "{{ _runtime_deps | rejectattr('name', 'in', _decl) | map(attribute='name') | list }}"
-    # Only packages with a pinned version can be installed. cypress and
-    # @cypress/grep carry no version here because their major has to match the
-    # checkout, so a missing one is a hard failure rather than an install.
+    # cypress and @cypress/grep carry no version, because their major has to
+    # match the checkout. A missing one is a hard failure, not an install.
     _missing_deps_pinned: >-
       {{ _runtime_deps | rejectattr('name', 'in', _decl) | rejectattr('version', 'eq', '')
          | map(attribute='name') | zip(_runtime_deps | rejectattr('name', 'in', _decl)

--- a/ansible/testing/dashboard-e2e/templates/env.j2
+++ b/ansible/testing/dashboard-e2e/templates/env.j2
@@ -40,3 +40,7 @@ CYPRESS_ALLOW_FILTERED_CATALOG_SKIP={{ allow_filtered_catalog_skip | default(tru
 CYPRESS_BROWSER={{ cypress_browser | default('chrome') }}
 RANCHER_IMAGE_TAG={{ rancher_image_tag_resolved | default(rancher_image_tag) }}
 RANCHER_VERSION={{ rancher_version | default('') }}
+
+# Packages the checkout does not declare, installed by cypress.sh at container
+# start. Exact name@version pairs, space separated, empty when none are missing.
+MISSING_RUNTIME_DEPS={{ _missing_deps_pinned | default('') }}

--- a/ansible/testing/dashboard-e2e/templates/env.j2
+++ b/ansible/testing/dashboard-e2e/templates/env.j2
@@ -42,5 +42,5 @@ RANCHER_IMAGE_TAG={{ rancher_image_tag_resolved | default(rancher_image_tag) }}
 RANCHER_VERSION={{ rancher_version | default('') }}
 
 # Packages the checkout does not declare, installed by cypress.sh at container
-# start. Exact name@version pairs, space separated, empty when none are missing.
+# start. Space separated name@version pairs, empty when none are missing.
 MISSING_RUNTIME_DEPS={{ _missing_deps_pinned | default('') }}


### PR DESCRIPTION
Release branches run their own specs but get master's dependency manifests overlaid on top, so they run under master's Cypress. Since upstream moved master to Cypress 15, that forces Cypress 15 onto specs written for Cypress 11.

The result is suites that fail to load rather than tests that fail:

```
release-2.15   23 of 51 run, 23 skipped
release-2.13   31 of 60 run, 23 skipped
```

## The fix

A checkout that carries its own `cypress/package.json` keeps it, and `cypress_version` is read from that file. This is the rule `run.sh` already applies to `--dashboard-dir`, so both modes now agree.

Branches older than `release-2.14` have no such file and still need an overlay. Rather than always taking master, the playbook reads the Cypress major the branch was written against and overlays from the nearest newer release branch pinning the same major, falling back to master. `release-2.13` therefore overlays from `release-2.14` and stays on Cypress 11. An explicit `dashboard_overlay_branch` still wins.

## Everything else

| Change | Why |
|---|---|
| Install pinned packages the checkout does not declare | Older branches predate `junit-report-merger`, `globby` and `find-test-names`, which `grep-filter.ts` and the report merge need |
| `experimentalSessionAndOrigin` only on the old stack | Cypress 11 will not accept a suite level `testIsolation` without it |
| Register the `getHostStats` task | Branches before master's guard call it from a shared `afterEach`, and an unhandled task skips the rest of the spec |
| Drop `videoUploadOnPasses` | Removed in Cypress 13, warned on every run, inert under `video: false` |
| Document the branch contract | `cypress/package.json` decides the version, the overlay, the grep registration and the installs, and was only mentioned in passing |

## Verified on Jenkins

Seventeen builds against the staging job covering master, release-2.13 and release-2.15, with `create_initial_clusters` both true and false.

| Branch | Tags | Before | After |
|---|---|---|---|
| master | `@generic` | 53 of 53 | 53 of 53, unchanged |
| release-2.15 | `@generic` | 23 of 51, 23 skipped | 51 of 51 |
| release-2.13 | `@generic` | 31 of 60, 23 skipped | 59 of 60, 0 skipped |
| release-2.15 | `@importedCluster` | 1 test, 3 skipped | 4 tests, 0 skipped |
| release-2.15 | `@customCluster` | not run | 8 of 10, 0 skipped |

46 tests that never ran now run. Both sides of every new conditional were exercised, and the overlay resolution was additionally run against nine synthetic cases covering the fallback, an explicit override and a non release branch.

Remaining failures on the release branches are pre-existing DOM assertions, the same ones master fails. `@customCluster` provisioned a real RKE2 cluster to Active, which confirms the SSH key path and the three `cy.exec` calls in `cluster-manager.spec.ts`.