### PR TITLE
[Dashboard] - Record which Rancher build and UI a run tested

### DIFF
--- a/ansible/testing/dashboard-e2e/README.md
+++ b/ansible/testing/dashboard-e2e/README.md
@@ -266,6 +266,38 @@ The remaining AWS settings go in `vars.yaml`:
 | `k3s_kubernetes_version` | `v1.30.0+k3s1` | K3s version for all clusters |
 | `bootstrap_password` | `password` | Rancher first-boot password |
 | `rancher_password` | `password1234` | Permanent admin password set after bootstrap |
+| `ui_offline_preferred` | unset | Pin the UI to the one the image embeds. See "Which UI the tests run against" below |
+
+### Which UI the tests run against
+
+Rancher does not necessarily serve the UI that ships inside its image. The
+`ui-offline-preferred` setting decides, and its default is `dynamic`:
+
+| Image | `dynamic` serves | The image itself embeds |
+|-------|------------------|-------------------------|
+| `v2.15.0` | the UI in the image | `v2.15.0` |
+| `v2.15-head` | `releases.rancher.com/dashboard/release-2.15/`, rebuilt from the branch | `v2.15.0`, the last GA build |
+| `head` (master) | `releases.rancher.com/dashboard/master/` | `master` |
+
+The default is usually what a release branch run wants. A `-head` image embeds
+the last GA UI, not the branch's, so pinning the UI to the image would test a
+current backend against weeks old UI and would not exercise any UI change made
+on the branch. Only `head` off master embeds a UI matching its own branch.
+
+The cost of the default is that the branch path is rebuilt continuously, so two
+runs of the same tag minutes apart can serve different UI builds. Rather than
+change what is tested, the playbook records what was tested: the Rancher build,
+the image digest and where the UI came from are printed after deployment, so a
+result can be tied to a build afterwards.
+
+Set `ui_offline_preferred: "true"` to pin the UI to the image anyway, when a
+run needs to be repeatable and testing the branch's UI is not the point, for
+example when validating a change to the tests themselves. The playbook then
+asserts the setting took effect.
+
+Note that pinning can mask a UI regression: in one run a broken branch UI failed
+nine of ten tests, while the same backend with the image's own UI failed only
+the one test caused by the backend.
 
 ### Helm Repos and Image Resolution
 

--- a/ansible/testing/dashboard-e2e/tasks/install-k3s-rancher.yml
+++ b/ansible/testing/dashboard-e2e/tasks/install-k3s-rancher.yml
@@ -108,6 +108,16 @@
       password: '{{ rancher_password }}'
       rancher_chart_repo: '{{ rancher_helm_repo }}'
       rancher_chart_repo_url: '{{ rancher_chart_url }}'
+      {% if ui_offline_preferred is defined %}
+      # Opt in only. See "Which UI the tests run against" in the README: on a
+      # release branch `-head` tag this pins the UI to the one the image embeds,
+      # which is the last GA build, not the branch. That makes a run repeatable
+      # at the cost of no longer exercising the branch's UI.
+      extra_helm_values:
+        extraEnv:
+          - name: CATTLE_UI_OFFLINE_PREFERRED
+            value: '{{ ui_offline_preferred }}'
+      {% endif %}
     dest: "{{ outputs_dir }}/rancher-vars.yaml"
     mode: "0644"
   when: job_type == 'recurring'
@@ -136,3 +146,129 @@
   delay: 10
   changed_when: false
   when: create_initial_clusters | bool
+
+# Reported unconditionally, because a rolling tag serves a different UI from one
+# run to the next and the log otherwise gives no way to tell which one a result
+# came from.
+- name: Read which UI Rancher serves
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ outputs_dir }}/kubeconfig-rancher.yaml"
+    api_version: management.cattle.io/v3
+    kind: Setting
+    name: "{{ item }}"
+  loop:
+    - ui-offline-preferred
+    - ui-dashboard-index
+  register: _ui_settings
+  until: _ui_settings.resources | default([]) | length > 0
+  retries: 30
+  delay: 10
+  failed_when: false
+  when: job_type == 'recurring'
+
+- name: Assert Rancher serves the UI embedded in the image
+  vars:
+    _setting: "{{ (_ui_settings.results | first).resources | default([]) | first | default({}, true) }}"
+    # `value` is what an operator set, `default` is what the deployment was
+    # given, which is where CATTLE_ env vars land. The effective setting is
+    # `value` when it is non-empty, otherwise `default`.
+    _effective: "{{ _setting.value | default('', true) or _setting.default | default('', true) }}"
+  ansible.builtin.assert:
+    that: _effective == ui_offline_preferred
+    success_msg: "ui-offline-preferred={{ _effective }}, as requested."
+    fail_msg: >-
+      ui-offline-preferred={{ _effective | default('unset', true) }}, but
+      ui_offline_preferred={{ ui_offline_preferred }} was requested.
+      CATTLE_UI_OFFLINE_PREFERRED did not reach the deployment.
+  when:
+    - job_type == 'recurring'
+    - ui_offline_preferred is defined
+
+# A rolling tag names a different build from one hour to the next, and the chart
+# version reported earlier is not the build either: `v2.15-head` resolves to
+# chart 2.15.0 whichever commit it was cut from. Record what actually ran, so a
+# result can be tied to a build afterwards. `server-version` carries Rancher's
+# own string, which for a `-head` image is `v{minor}-{commit}-head`, and the
+# pod carries the digest the node pulled.
+- name: Read the Rancher server version
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ outputs_dir }}/kubeconfig-rancher.yaml"
+    api_version: management.cattle.io/v3
+    kind: Setting
+    name: server-version
+  register: _rancher_version
+  failed_when: false
+  when: job_type == 'recurring'
+
+- name: Read the Rancher pods
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ outputs_dir }}/kubeconfig-rancher.yaml"
+    kind: Pod
+    namespace: cattle-system
+    label_selectors:
+      - app=rancher
+  register: _rancher_pods
+  failed_when: false
+  when: job_type == 'recurring'
+
+# Reported rather than asserted: an unidentified build is worth knowing about
+# but is not a reason to fail a run that otherwise has results.
+- name: Resolve what the run is testing
+  vars:
+    _setting: "{{ (_rancher_version.resources | default([]) | first) | default({}, true) }}"
+    _pod: "{{ (_rancher_pods.resources | default([]) | first) | default({}, true) }}"
+    _ui_offline_res: "{{ (_ui_settings.results | default([]) | first) | default({}, true) }}"
+    _ui_index_res: "{{ (_ui_settings.results | default([]) | last) | default({}, true) }}"
+    _ui_offline_obj: "{{ (_ui_offline_res.resources | default([]) | first) | default({}, true) }}"
+    _ui_index_obj: "{{ (_ui_index_res.resources | default([]) | first) | default({}, true) }}"
+  ansible.builtin.set_fact:
+    _rancher_container: "{{ (_pod.status | default({}, true)).containerStatuses | default([], true) | first | default({}, true) }}"
+    _server_version: "{{ _setting.value | default('', true) or _setting.default | default('', true) }}"
+    _ui_offline_value: "{{ _ui_offline_obj.value | default('', true) or _ui_offline_obj.default | default('', true) }}"
+    _ui_index_value: "{{ _ui_index_obj.value | default('', true) or _ui_index_obj.default | default('', true) }}"
+  when: job_type == 'recurring'
+
+- name: Decide where the UI came from
+  vars:
+    # `dynamic` resolves through settings.IsRelease(), which is
+    # `!strings.Contains(serverVersion, "head") && regexp("^v[0-9]").Match(serverVersion)`.
+    # A release serves the UI it embeds, anything else serves ui-dashboard-index.
+    _is_release: "{{ 'head' not in _server_version and _server_version is match('^v[0-9]') }}"
+  ansible.builtin.set_fact:
+    _ui_from_image: "{{ _ui_offline_value == 'true' or (_ui_offline_value == 'dynamic' and _is_release) }}"
+  when: job_type == 'recurring'
+
+# The CDN path is rebuilt from the release branch continuously and carries no
+# version, so the image digest alone does not identify what ran. The bundle name
+# is content hashed, which makes it a usable fingerprint: two runs naming the
+# same bundle loaded the same UI. The build date narrows down the commit that
+# produced it.
+- name: Fingerprint the UI when it is served from the CDN
+  ansible.builtin.uri:
+    url: "{{ _ui_index_value }}"
+    return_content: true
+  register: _ui_fetch
+  failed_when: false
+  when:
+    - job_type == 'recurring'
+    - not _ui_from_image
+    - _ui_index_value | length > 0
+
+- name: Report the Rancher build under test
+  vars:
+    # Hashing the index rather than naming a bundle in it: the release branches
+    # and master lay their assets out differently, and the index changes
+    # whenever any of them does. Two runs reporting the same hash loaded the
+    # same UI. The build date narrows down the commit that produced it.
+    _ui_hash: "{{ (_ui_fetch.content | default('', true) | hash('sha1'))[:12] if (_ui_fetch.content | default('', true) | length) > 0 else 'unknown' }}"
+    _built: "{{ _ui_fetch.last_modified | default('unknown', true) }}"
+  ansible.builtin.debug:
+    msg: "{{ ['server-version: ' ~ (_server_version | default('unknown', true)),
+              'image:          ' ~ (_rancher_container.image | default('unknown', true)),
+              'digest:         ' ~ (_rancher_container.imageID | default('unknown', true)),
+              'ui-offline:     ' ~ (_ui_offline_value | default('unknown', true))]
+             + (['ui:             the image'] if _ui_from_image
+                else ['ui:             ' ~ _ui_index_value,
+                      'ui build:       ' ~ _ui_hash ~ ' (sha1 of index, changes with the UI)',
+                      'ui built:       ' ~ _built]) }}"
+  when: job_type == 'recurring'

--- a/ansible/testing/dashboard-e2e/vars.yaml.example
+++ b/ansible/testing/dashboard-e2e/vars.yaml.example
@@ -29,6 +29,13 @@ cert_manager_version: "1.11.0"
 bootstrap_password: "password"
 rancher_password: "password1234"
 rancher_username: "admin"
+# Pin the UI to the one the Rancher image embeds. Leave unset for the Rancher
+# default, which on a release branch `-head` tag serves the branch's UI from
+# releases.rancher.com; the image itself embeds the last GA UI, so pinning
+# would test a current backend against a weeks old UI. Set to "true" when a run
+# needs to be repeatable and the branch's UI is not what is under test, for
+# example when validating a change to the tests themselves.
+# ui_offline_preferred: "true"
 
 # --- Test-runner pinned versions ---
 # Keep in sync with: https://github.com/cypress-io/cypress-docker-images/blob/master/factory/.env


### PR DESCRIPTION
A `-head` tag names a different build from one hour to the next, and the log did not say which one a run got. Every one of these was a separate image:

```
"msg": "Rancher 2.15.0-rc5, image_tag=v2.15-head, helm_repo=rancher-com-rc"
```

Chasing a flake across five runs earlier today, four of them reported that exact line while running different code. Two runs 56 minutes apart:

| Build | Time | server-version | Digest |
|-------|------|----------------|--------|
| 377 | 13:24 | `v2.15-51e13ab7c070...-head` | `sha256:a7639689f309` |
| 379 | 14:20 | `v2.15-c12590f21a8c...-head` | `sha256:00da2cf01def` |

## The fix

Report what a run actually tested, after Rancher is up:

```
server-version: v2.15-c12590f21a8c4c0a521a4a827b4745dfbcf88f04-head
image:          docker.io/rancher/rancher:v2.15-head
digest:         docker.io/rancher/rancher@sha256:00da2cf01def3533...
ui-offline:     dynamic
ui:             https://releases.rancher.com/dashboard/release-2.15/index.html
ui build:       2c1284817689 (sha1 of index, changes with the UI)
ui built:       Wed, 05 Aug 2026 18:09:10 GMT
```

`server-version` carries `v{minor}-{commit}-head`, and that commit is a pullable tag, so a run can be reproduced with:

```yaml
rancher_image_tag: "v2.15-c12590f21a8c4c0a521a4a827b4745dfbcf88f04-head"
```

The image alone does not identify a `-head` run, because the UI does not come from it. `ui-offline-preferred` defaults to `dynamic`, which serves the UI a released image embeds but fetches it from `releases.rancher.com` for a `-head` build, and that path is rebuilt from the release branch continuously. Hashing the index Rancher points at gives a fingerprint: two runs naming the same hash loaded the same UI, and the build date narrows down the commit. The index is hashed rather than a bundle inside it because the release branches and master lay their assets out differently.

## `ui_offline_preferred` is optional and off

The default is untouched. Set it only when a run needs to be repeatable and the branch's UI is not what is under test, for example when validating a change to the tests themselves. It is asserted when set.

Leaving it off is deliberate. A release branch `-head` image embeds the last GA UI, not the branch's: `v2.15-head` embeds `v2.15.0` and `v2.14-head` embeds `v2.14.4`. Pinning there would test a current backend against weeks old UI and would not exercise any UI change made on the branch. It also hides regressions: with the branch UI a run failed nine of ten tests because the create page did not render, while the same backend with the image's UI failed only the one test the backend caused.

## Verified on Jenkins

Six builds, both branches of every conditional.

| Build | Image | `ui_offline_preferred` | Reported | Tests |
|-------|-------|------------------------|----------|-------|
| 376 | `v2.15-head` | unset | `dynamic`, UI from CDN, assert skipped | 20 of 20 |
| 377 | `v2.15-head` | `true` | `true`, UI from image, assert passed | 20 of 20 |
| 379 | `v2.15-head` | unset | fingerprint `2c1284817689` | 20 of 20 |
| 380 | `v2.15.0` | unset | UI from image, fetch skipped | 19 of 19 |
| 378 | `v2.14.4` | unset | UI from image | 10 of 10 |
| 375 | `v2.15.0` | `true` | UI from image | 10 of 10 |

`dynamic` resolves through `settings.IsRelease()`, which is `!strings.Contains(serverVersion, "head") && regexp("^v[0-9]").Match(serverVersion)`. Both sides were confirmed against what the runs actually fetched: the GA image made no request to `releases.rancher.com`, the `-head` image made twelve.

The settings are read with `kubernetes.core.k8s_info`, already a dependency here and used by the k3s and rke2 playbooks. Reporting never fails a run: a missing field is printed as `unknown`.
