### PR TITLE
[cluster_nodes] Add optional dedicated SSH SG to avoid prefix-list propagation lag

### DIFF
--- a/tofu/aws/modules/cluster_nodes/README.md
+++ b/tofu/aws/modules/cluster_nodes/README.md
@@ -70,6 +70,37 @@ The first node in the first group with `etcd` role becomes the `master` node.
 
 **Important:** Nodes with the same role must be in a single group (e.g., `{ count = 2, role = ["etcd"] }`). Splitting them into multiple groups causes duplicate hostname conflicts.
 
+### SSH access (avoiding prefix-list propagation lag)
+
+`create_ssh_security_group` (default `false`) — opt in to have the module create a
+**dedicated** security group that grants SSH (port 22) from a list of **stable** CIDRs
+(`ssh_allowed_cidrs`) plus the VPC's own CIDR, attached to every node **alongside**
+`aws_security_group`.
+
+**Enable this when your jumpbox/bastion/office IP is allowed SSH only through a
+*managed prefix list* referenced by `aws_security_group`.** AWS propagates
+prefix-list SG rules to each instance's ENI **asynchronously**, so on freshly-launched
+instances one random ENI can lag or land on a stale list version and silently drop SSH
+SYN packets to that node until propagation completes. This surfaces as *"one node
+randomly unreachable on SSH right after `apply`"* — host firewall open, VPC-internal
+SSH working, but a TCP connect timeout from the jumpbox, with a **different node
+affected each build**. Plain CIDR SG rules, by contrast, are realized on the ENI
+**immediately at launch**, so SSH always works.
+
+AWS security groups are **additive** (a flow is allowed if *any* attached SG allows
+it), so this layers on top of `aws_security_group` — the existing RKE2/Rancher port
+matrix in the shared SG is left untouched. The new SG is owned by this module and is
+destroyed automatically on `terraform destroy`.
+
+```terraform
+create_ssh_security_group = true
+ssh_allowed_cidrs         = ["45.33.107.248/32"]   # jumpbox / bastion / office egress
+```
+
+VPC-internal SSH is allowed automatically (from the VPC CIDR), so node-to-node access
+(e.g. Ansible run from a node, or reaching one node from another) always works
+regardless of this setting. The created SG's ID is exported as `ssh_security_group_id`.
+
 ## Outputs
 
 Refer to `outputs.tf` for a list of exported values.
@@ -95,6 +126,10 @@ aws_volume_type       = "gp3"
 aws_hostname_prefix   = "hostnameprefix"
 aws_ssh_user          = "ec2-user"
 public_ssh_key        = "sshkey"
+# Optional: grant SSH from a stable /32 (jumpbox/bastion) via a dedicated SG.
+# Avoids managed-prefix-list propagation lag — see "SSH access" above.
+# create_ssh_security_group = true
+# ssh_allowed_cidrs         = ["203.0.113.10/32"]
 nodes = [
   {
     count = 3

--- a/tofu/aws/modules/cluster_nodes/main.tf
+++ b/tofu/aws/modules/cluster_nodes/main.tf
@@ -50,12 +50,64 @@ resource "aws_key_pair" "ssh_public_key" {
   public_key = file(var.public_ssh_key)
 }
 
+# Dedicated SSH security group with stable CIDR rules.
+#
+# Why this exists: when SSH access for the jumpbox/bastion is granted ONLY via a
+# managed prefix list (e.g. a churning "QA public IPs" list), AWS propagates the
+# prefix-list entries to each new instance's ENI asynchronously. On freshly
+# launched instances one ENI can lag or land on a stale list version and silently
+# drop the jumpbox's SSH SYN to that node until propagation catches up - so one
+# random node per build looks "unreachable" for minutes. Plain CIDR SG rules, by
+# contrast, are realized on the ENI immediately at launch, so SSH from the
+# jumpbox always works.
+#
+# This SG is attached ALONGSIDE var.aws_security_group (AWS SGs are additive: a
+# flow is allowed if ANY attached SG allows it), so the existing RKE2/Rancher
+# port matrix in the shared SG is left untouched.
+resource "aws_security_group" "ssh" {
+  count       = var.create_ssh_security_group ? 1 : 0
+  name        = "tf-${var.aws_hostname_prefix}-ssh"
+  description = "Stable SSH (22) access for ${var.aws_hostname_prefix} (avoids prefix-list propagation lag)."
+  vpc_id      = var.aws_vpc
+
+  dynamic "ingress" {
+    for_each = length(var.ssh_allowed_cidrs) > 0 ? [1] : []
+    content {
+      description = "SSH from stable CIDRs (jumpbox/bastion/office)"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = var.ssh_allowed_cidrs
+    }
+  }
+
+  ingress {
+    description = "SSH from within the VPC"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.selected.cidr_block]
+  }
+
+  egress {
+    description = "Allow all egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "tf-${var.aws_hostname_prefix}-ssh"
+  }
+}
+
 resource "aws_instance" "node" {
   for_each = { for node in local.node_names : node.name => node }
   ami = var.aws_ami
   instance_type = each.value.instance_type != null ? each.value.instance_type : var.instance_type
   key_name = aws_key_pair.ssh_public_key.key_name
-  vpc_security_group_ids = var.aws_security_group
+  vpc_security_group_ids = compact(concat(var.aws_security_group, var.create_ssh_security_group ? [aws_security_group.ssh[0].id] : []))
   subnet_id = var.aws_subnet
   associate_public_ip_address = var.airgap_setup || var.proxy_setup ? false : true
 
@@ -235,4 +287,9 @@ resource "aws_route53_record" "aws_route53" {
 data "aws_route53_zone" "selected" {
   name = var.aws_route53_zone
   private_zone = false
+}
+
+# Used to auto-allow SSH from the VPC's own CIDR in the dedicated SSH SG above.
+data "aws_vpc" "selected" {
+  id = var.aws_vpc
 }

--- a/tofu/aws/modules/cluster_nodes/outputs.tf
+++ b/tofu/aws/modules/cluster_nodes/outputs.tf
@@ -32,3 +32,8 @@ output "cluster_nodes_json" {
     ]
   })
 }
+
+output "ssh_security_group_id" {
+  description = "ID of the dedicated SSH security group created when create_ssh_security_group=true; null otherwise."
+  value       = var.create_ssh_security_group ? aws_security_group.ssh[0].id : null
+}

--- a/tofu/aws/modules/cluster_nodes/variables.tf
+++ b/tofu/aws/modules/cluster_nodes/variables.tf
@@ -51,4 +51,14 @@ variable "ssh_allowed_cidrs" {
   description = "Stable IPv4 CIDRs allowed SSH (22) when create_ssh_security_group=true. Use /32s for jumpboxes/bastions, e.g. [\"45.33.107.248/32\"]. VPC-internal SSH is allowed automatically in addition to these."
   type        = list(string)
   default     = []
+  validation {
+    # Reject world-open SSH. Scoped to the genuinely dangerous-but-valid case
+    # (0.0.0.0/0, ::/0); narrower-but-broad CIDRs (office /16, /24) are
+    # legitimate and left to the caller's judgement.
+    condition = alltrue([
+      for c in var.ssh_allowed_cidrs :
+      c != "0.0.0.0/0" && c != "::/0"
+    ])
+    error_message = "ssh_allowed_cidrs must not contain 0.0.0.0/0 or ::/0 (world-open SSH is not permitted). Use specific /32 or narrower CIDRs."
+  }
 }

--- a/tofu/aws/modules/cluster_nodes/variables.tf
+++ b/tofu/aws/modules/cluster_nodes/variables.tf
@@ -40,3 +40,15 @@ variable "nodes" {
 }
 variable "airgap_setup" {}
 variable "proxy_setup" {}
+
+variable "create_ssh_security_group" {
+  description = "Create a dedicated SG that grants SSH (22) from stable CIDRs (ssh_allowed_cidrs) plus the VPC CIDR, and attach it alongside var.aws_security_group. Enable when SSH access is granted only via a managed prefix list - prefix-list rules propagate to each new ENI asynchronously and can silently drop SSH to a freshly launched node; plain CIDR rules realize instantly."
+  type        = bool
+  default     = false
+}
+
+variable "ssh_allowed_cidrs" {
+  description = "Stable IPv4 CIDRs allowed SSH (22) when create_ssh_security_group=true. Use /32s for jumpboxes/bastions, e.g. [\"45.33.107.248/32\"]. VPC-internal SSH is allowed automatically in addition to these."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## What

Adds an opt-in **dedicated SSH security group** to the `cluster_nodes` module, attached alongside the existing `aws_security_group`, so SSH (22) from a stable CIDR (jumpbox/bastion) is authorized via a **plain CIDR rule** instead of only a managed prefix list.

## Why

When the jumpbox/bastion IP is authorized for SSH only through a managed prefix list, AWS propagates prefix-list SG rules to each new instance's ENI **asynchronously**. On freshly-launched instances one random ENI can lag or land on a stale list version and silently drop SSH SYN packets to that node — surfacing as _"one node randomly unreachable on SSH right after `tofu apply`"_: host firewall open, VPC-internal SSH working, TCP connect timeout from the jumpbox, with a **different node affected each build**.

Plain CIDR SG rules realize on the ENI immediately at launch, eliminating this flaky failure mode.

AWS SGs are additive (a flow is allowed if any attached SG allows it), so this layers on top of `aws_security_group` without touching the existing RKE2/Rancher port matrix. The SG is module-owned and destroyed on `tofu destroy`.

## Changes

- `variables.tf`: `create_ssh_security_group` (bool, default `false`), `ssh_allowed_cidrs` (list(string))
- `main.tf`: `aws_security_group.ssh`, `data.aws_vpc.selected` (auto-allows VPC-internal SSH), instance `vpc_security_group_ids` wiring
- `outputs.tf`: `ssh_security_group_id`
- `README.md`: documents the feature, the symptom it fixes, and when to enable it

## Usage

```hcl
create_ssh_security_group = true
ssh_allowed_cidrs         = ["203.0.113.10/32"]   # jumpbox / bastion / office egress
```

Opt-in; existing users see no change (`create_ssh_security_group` defaults to `false`). VPC-internal SSH is allowed automatically regardless of this setting.

## Validation

- `tofu validate` → `Success! The configuration is valid.`
- Verified end-to-end on a live cluster: with the feature enabled, the stable `/32` is realized on every ENI at launch and the random-node SSH timeout no longer reproduces.
