### PR TITLE
[Dashboard] - Keep the import cluster on private addresses

### DIFF
--- a/ansible/testing/dashboard-e2e/tasks/install-k3s-rancher.yml
+++ b/ansible/testing/dashboard-e2e/tasks/install-k3s-rancher.yml
@@ -1,6 +1,12 @@
 # Install K3s on clusters and deploy Rancher via Helm.
 # K3s installs run in parallel (rancher-server + importcluster).
 # Rancher is deployed after K3s is ready using the rancher-ha playbook.
+#
+# Both clusters set k3s_node_external_ip to false. Otherwise k3s advertises the
+# node's public IP, making that the kubernetes service endpoint. The security
+# group only allows node to node traffic over private addresses, so CoreDNS
+# cannot reach the API server, never becomes ready, and the cluster agent
+# crash loops on an unresolvable Rancher host.
 
 - name: Write k3s vars for rancher server
   ansible.builtin.copy:
@@ -38,6 +44,7 @@
       kubeconfig_file: '{{ outputs_dir }}/kubeconfig-import.yaml'
       node_token_file: '/tmp/node_token_import.txt'
       channel: "stable"
+      k3s_node_external_ip: false
     dest: "{{ outputs_dir }}/import-k3s-vars.yaml"
     mode: "0644"
   when: create_initial_clusters | bool


### PR DESCRIPTION
Every `@importedCluster` test failed, and the reason was not in the tests. The imported cluster never became active because its `cattle-cluster-agent` could not resolve the Rancher host:

```
cattle-cluster-agent   0/1   CrashLoopBackOff
ERROR: https://jnkui-...qa.rancher.space/ping is not accessible (Could not resolve host)
```

It could not resolve anything, because CoreDNS never became ready:

```
coredns-76c974cb66-57zjv   0/1   Running   111m
Readiness probe failed: HTTP probe failed with statuscode: 503  (x3340 over 111m)
[INFO] plugin/ready: Plugins not ready: "kubernetes"
```

CoreDNS could not reach the API server. The k3s role advertises the node's public IP unless told otherwise, and k3s uses that as its advertise address, so the `kubernetes` service endpoint became the public IP. The security group only permits node to node traffic over private addresses, so that traffic was dropped.

The rancher server cluster already set `k3s_node_external_ip: false`. The import cluster did not. Same run, same security group:

| Cluster | `k3s_node_external_ip` | `kubernetes` endpoint | CoreDNS |
|---------|------------------------|-----------------------|---------|
| rancher-server | `false` | `192.168.12.228:6443` | 1/1 |
| importcluster | unset, defaults true | `13.56.183.183:6443` | 0/1 |

The custom node is not installed by this role at all. Rancher installs RKE2 there itself through the registration command, which advertises the private IP, which is why only imported clusters were affected and the custom cluster tests kept passing.

## The fix

Set `k3s_node_external_ip: false` for the import cluster, matching the rancher server cluster.

## Testing

Provisioned from scratch on `release-2.14` and on `release-2.15`, `create_initial_clusters: true`, us-west-1.

Before and after, on fresh infrastructure each time:

```
before   kubernetes endpoint 13.56.183.183:6443 (public)    CoreDNS 0/1 after 111m
after    kubernetes endpoint 192.168.5.1:6443   (private)   CoreDNS 1/1 after 3m45s
```

`@importedCluster` against `v2.14-head`, having failed every test before:

```
Cluster Manager
  Imported
    Generic
      ✓ can create new cluster (42686ms)
      ✓ can edit imported cluster and see changes afterwards (5832ms)
      ✓ can delete cluster by bulk actions

  3 passing (53s)
```

The spec changes those runs also carry are separate and are going to rancher/dashboard.
