### PR TITLE
feat(airgap): self-provision security group when none supplied

### DIFF
--- a/tofu/aws/modules/airgap/README.md
+++ b/tofu/aws/modules/airgap/README.md
@@ -145,7 +145,11 @@ aws_access_key        = "key"
 aws_secret_key        = "secretkey"
 aws_ami               = "ami-"
 instance_type         = "t3.xlarge"
-aws_security_group    = ["sg-"]
+# aws_security_group is optional. When omitted (or set to []) the module
+# provisions its own security group inside var.aws_vpc that opens SSH, the
+# intra-group traffic the RKE2/Rancher cluster needs, and the load balancer
+# listener ports (80, 443, 6443, 9345). Set it to reuse a pre-existing group.
+# aws_security_group  = ["sg-"]
 aws_subnet_airgap     = "subnet-0b80e9a553633f5a9" # This subnet should not allow internet connectivity
 aws_subnet_bastion    = "subnet-ee8cac86"
 aws_volume_size       = 500

--- a/tofu/aws/modules/airgap/main.tf
+++ b/tofu/aws/modules/airgap/main.tf
@@ -13,6 +13,82 @@ provider "aws" {
   secret_key = var.aws_secret_key
 }
 
+locals {
+  # Ports the network load balancers forward on to the rancher targets. The
+  # NLBs themselves carry no security group, so the listener ports must be
+  # opened directly on the instances for the forwarded traffic to land.
+  ports = ["80", "443", "6443", "9345"]
+
+  # When no pre-existing security group is supplied, provision one inside the
+  # airgap VPC so the module is self-contained. Callers can still pass their
+  # own group id(s) via var.aws_security_group to reuse an existing group.
+  create_security_group = length(var.aws_security_group) == 0
+  security_group_ids    = local.create_security_group ? [aws_security_group.airgap[0].id] : var.aws_security_group
+}
+
+# Security group shared by the bastion, registry (when provisioned) and all
+# airgap cluster nodes. It lives in the airgap VPC and:
+#   * allows SSH from the operator (configurable CIDR, default anywhere),
+#   * allows full intra-group traffic so the bastion can reach the nodes and
+#     the RKE2/Rancher cluster nodes can talk to each other (etcd, kube-api,
+#     flannel VXLAN, etc.) without enumerating every cluster port,
+#   * opens the NLB listener ports so load-balanced traffic reaches the nodes,
+#   * permits all egress.
+# Note: airgap isolation is still enforced at the subnet level -- the airgap
+# subnet has no route to an internet gateway -- so the permissive egress here
+# does not break airgap-ness for the nodes in that subnet.
+resource "aws_security_group" "airgap" {
+  count       = local.create_security_group ? 1 : 0
+  name        = "${var.aws_hostname_prefix}-airgap"
+  description = "Security group for the ${var.aws_hostname_prefix} airgap deployment (bastion, registry, cluster nodes)"
+  vpc_id      = var.aws_vpc
+
+  # Operator SSH access to the bastion (and any instance sharing this group).
+  dynamic "ingress" {
+    for_each = toset(var.allowed_ssh_cidr)
+    content {
+      description = "SSH from ${ingress.value}"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  # Full intra-group communication: bastion -> nodes and node <-> node.
+  ingress {
+    description = "All traffic between instances in this security group"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+  }
+
+  # NLB listener ports forwarded on to the rancher targets.
+  dynamic "ingress" {
+    for_each = toset(local.ports)
+    content {
+      description = "LB listener ${ingress.value} from load balancer clients"
+      from_port   = tonumber(ingress.value)
+      to_port     = tonumber(ingress.value)
+      protocol    = "tcp"
+      cidr_blocks = var.allowed_lb_cidr
+    }
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.aws_hostname_prefix}-airgap"
+  }
+}
+
 # Bastion
 module "bastion" {
   source = "./../ec2_instance"
@@ -21,7 +97,7 @@ module "bastion" {
   instance_type = var.instance_type
   subnet_id = var.aws_subnet_bastion
   ssh_key_name = var.ssh_key_name
-  security_group_ids = var.aws_security_group
+  security_group_ids = local.security_group_ids
   volume_size = var.aws_volume_size
   user_id = var.user_id
   ssh_key = var.ssh_key
@@ -37,15 +113,11 @@ module "registry" {
   instance_type = var.instance_type
   subnet_id = var.aws_subnet_bastion
   ssh_key_name = var.ssh_key_name
-  security_group_ids = var.aws_security_group
+  security_group_ids = local.security_group_ids
   volume_size = var.aws_volume_size
   user_id = var.user_id
   ssh_key = var.ssh_key
   associate_public_ip = true
-}
-
-locals {
-  ports = ["80", "443", "6443", "9345"]
 }
 
 # Load Balance
@@ -84,7 +156,7 @@ module "airgap_nodes" {
   instance_type = var.instance_type
   subnet_id = var.aws_subnet_airgap
   ssh_key_name = var.ssh_key_name
-  security_group_ids = var.aws_security_group
+  security_group_ids = local.security_group_ids
   volume_size = var.aws_volume_size
   user_id = var.user_id
   ssh_key = var.ssh_key

--- a/tofu/aws/modules/airgap/outputs.tf
+++ b/tofu/aws/modules/airgap/outputs.tf
@@ -6,6 +6,11 @@ output "bastion_public_dns" {
   value = module.bastion.public_dns
 }
 
+output "security_group_id" {
+  description = "ID of the security group attached to the bastion, registry and airgap nodes. Null when the caller supplied their own group(s) via var.aws_security_group."
+  value       = local.create_security_group ? aws_security_group.airgap[0].id : null
+}
+
 output "rancher_airgap_nodes_private_ips" {
   value = [for key, instance in module.airgap_nodes : instance.private_ip if startswith(instance.name, "${var.aws_hostname_prefix}-rancher-")]
 }

--- a/tofu/aws/modules/airgap/variables.tf
+++ b/tofu/aws/modules/airgap/variables.tf
@@ -16,7 +16,21 @@ variable "aws_ami" {}
 variable "aws_hostname_prefix" {}
 variable "aws_route53_zone" {}
 variable "aws_ssh_user" {}
-variable "aws_security_group" { type = list(string) }
+variable "aws_security_group" {
+  description = "Optional list of pre-existing security group IDs to attach to every instance. When empty (the default) the module provisions its own security group inside var.aws_vpc."
+  type        = list(string)
+  default     = []
+}
+variable "allowed_ssh_cidr" {
+  description = "CIDR blocks allowed to reach SSH (tcp/22) on the bastion and cluster nodes. Defaults to anywhere; restrict to your operator/admin ranges in production."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+variable "allowed_lb_cidr" {
+  description = "CIDR blocks allowed to reach the NLB listener ports (80, 443, 6443, 9345) that the load balancers forward on to the rancher nodes. Defaults to anywhere for an internet-facing deployment."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
 variable "aws_vpc" {}
 variable "aws_volume_size" {}
 variable "aws_subnet_airgap" {


### PR DESCRIPTION
## Summary

All security groups were removed in AWS, which broke the airgap OpenTofu module: it previously only **consumed** a pre-existing security group via `var.aws_security_group` (shared by the bastion, registry, and every airgap node), so `tofu apply` failed on the dangling SG reference.

This makes the module **self-contained** — it now provisions its own security group inside `var.aws_vpc` when none is supplied, while remaining backward-compatible for callers that pass an existing group.

## Changes

- **`main.tf`** — added `aws_security_group.airgap` (created in the airgap VPC, gated by `count`) and a `locals` block that selects it when `var.aws_security_group` is empty; rewired the bastion, registry, and `airgap_nodes` modules to `local.security_group_ids`; removed the now-duplicate standalone `ports` local.
- **`variables.tf`** — `aws_security_group` is now optional (`default = []`); added `allowed_ssh_cidr` and `allowed_lb_cidr` (both default `["0.0.0.0/0"]`) so source ranges are lock-down-able.
- **`outputs.tf`** — exposed `security_group_id` (null when a caller supplies their own group).
- **`README.md`** — documented the auto-provisioning and made the sample `aws_security_group` optional.

## Rules on the new SG

| Direction | Protocol / Port | Source | Purpose |
|---|---|---|---|
| ingress | TCP 22 | `allowed_ssh_cidr` | Operator SSH to the bastion |
| ingress | all (`-1`) | `self` | bastion↔nodes + node↔node RKE2/Rancher comms (etcd, kube-api, flannel VXLAN, …) |
| ingress | TCP 80/443/6443/9345 | `allowed_lb_cidr` | NLB listener ports (NLBs carry no SG, so the targets must allow these directly) |
| egress | all (`-1`) | `0.0.0.0/0` | Outbound (bastion image/tarball pulls, etc.) |

Airgap isolation is **preserved**: it is still enforced at the subnet level (the airgap subnet has no IGW route), so the permissive egress does not break airgap-ness for nodes in that subnet. This is noted in an inline comment.

## Validation

- `tofu validate` → **Success**
- `tofu plan -refresh=false -target=aws_security_group.airgap` → `Plan: 1 to add` — creates `aws_security_group.airgap` (named `<prefix>-airgap`) in the airgap VPC with all seven rules above.
