### PR TITLE
Show kubeconfig path

### DIFF
--- a/ansible/k3s/default/k3s-playbook.yml
+++ b/ansible/k3s/default/k3s-playbook.yml
@@ -140,6 +140,11 @@
       run_once: true
       become: false
 
+    - name: Show kubeconfig_file
+      debug:
+        msg: "{{ kubeconfig_file }}"
+      run_once: true
+
     # Pick first cp-having host for kubeconfig URL — split-role master may be etcd-only and have no apiserver.
     - name: Pick a kube-apiserver-bearing host for the kubeconfig server URL
       set_fact:

--- a/ansible/k3s/default/k3s-playbook.yml
+++ b/ansible/k3s/default/k3s-playbook.yml
@@ -140,9 +140,9 @@
       run_once: true
       become: false
 
-    - name: Show kubeconfig_file
+    - name: Show path to kubeconfig
       debug:
-        msg: "{{ kubeconfig_file }}"
+        msg: "Kubeconfig content saved to {{ kubeconfig_file }}"
       run_once: true
 
     # Pick first cp-having host for kubeconfig URL — split-role master may be etcd-only and have no apiserver.
@@ -195,14 +195,12 @@
       slurp:
         src: "{{ node_token_file }}"
       delegate_to: localhost
-      run_once: true
       become: false
       register: node_token_file_content
 
     - name: Set node_token fact from file content
       set_fact:
         node_token: "{{ node_token_file_content.content | b64decode | trim }}"
-      run_once: true
       delegate_to: localhost
 
     - name: Create K3s server manifests directory on server nodes


### PR DESCRIPTION
This includes two changes to k3s-playbook.yml:
 - Showing the kubeconfig path
 - Avoid warning "Using run_once with the free strategy is not currently supported. This task will still be executed for every host in the inventory list."