### PR TITLE
[Dashboard] - Make a run leave a local dashboard checkout as it found it

### DIFF
--- a/ansible/testing/dashboard-e2e/README.md
+++ b/ansible/testing/dashboard-e2e/README.md
@@ -415,15 +415,22 @@ This is useful when:
 > are responsible for ensuring that their local code branch is compatible with the targeted
 > `rancher_helm_repo` and `rancher_image_tag`, otherwise tests may fail with unexpected UI errors.
 
-> **Branch requirement:** the checkout must carry its test dependencies in
-> `cypress/package.json` and `cypress/yarn.lock`. That layout exists from
-> `release-2.14` onwards. Older branches such as `release-2.13` keep the test
-> dependencies in the root `package.json`, which lacks the reporters and
-> preprocessor that `cypress.config.jenkins.ts` requires. Because the dependency
-> overlay is intentionally skipped for local checkouts, `--dashboard-dir` cannot
-> be used with them; `run.sh` rejects such a directory up front. Use the clone
-> path instead, which overlays the dependency manifests from
-> `dashboard_overlay_branch`.
+> **Branch requirement:** `--dashboard-dir` requires a `release-2.15` or newer
+> checkout. The checkout has to carry its test dependencies in
+> `cypress/package.json` and `cypress/yarn.lock`, and those manifests have to
+> declare the reporting and tag filtering packages: `cypress-multi-reporters`,
+> `mocha-junit-reporter`, `junit-report-merger`, `find-test-names` and `globby`.
+> `release-2.15` was the first branch to declare all of them. `release-2.14`
+> carries the manifests but not those packages, and `release-2.13` and older
+> keep the test dependencies in the root `package.json` altogether.
+>
+> The clone path fills either gap for you, by overlaying the manifests from
+> `dashboard_overlay_branch` and by installing whatever a branch leaves out. It
+> can do that because the clone is thrown away after the run. Your own checkout
+> is not, so nothing is ever written into it and the run refuses to start
+> instead. `run.sh` rejects such a directory up front, before any infrastructure
+> is provisioned. To test an older branch, drop `--dashboard-dir` and set
+> `dashboard_branch`.
 
 > **Cypress version:** the checkout supplies its own [branch
 > contract](#the-branch-contract), so `cypress_version` is read from its
@@ -437,18 +444,32 @@ This is useful when:
 
 > **Note:** The setup stage writes into your checkout to build the test image:
 > CI files in `cypress/jenkins/` (`Dockerfile.ci`, `cypress.sh`, and others),
-> `results.xml` and `cypress/jenkins/reports/` from the run, and with
-> `create_initial_clusters` an `imported_config` file holding the imported
-> cluster's kubeconfig. None are covered by dashboard's `.gitignore`, so clear
-> them before committing:
+> plus `results.xml` and `cypress/jenkins/reports/` from the run. Some of those
+> CI files are tracked in dashboard and the rest are not covered by its
+> `.gitignore`, so restore them before committing:
 >
 > ```bash
 > git checkout -- cypress/jenkins/
-> git clean -fd cypress/jenkins/ && rm -f imported_config results.xml
+> git clean -fd cypress/jenkins/ && rm -f results.xml
 > ```
 >
-> `./run.sh clean` does not touch them. It removes the wrapper's own artifacts
-> in this directory, the cloned checkout, `outputs/` and `.env`.
+> Nothing else in your checkout is modified. The imported cluster kubeconfig is
+> written to this playbook's `outputs/` rather than into your tree, and the
+> `node_modules` link the run creates at the checkout root is removed when the
+> run finishes. Branches that do not declare the reporting and tag filtering
+> packages get them installed into `cypress/node_modules` at container start,
+> and `cypress/package.json` is put back afterwards so it stays in step with
+> `cypress/yarn.lock`. That install runs with lifecycle scripts disabled and
+> with the cloud credentials and reporting tokens removed from its environment,
+> since it needs neither.
+>
+> `./run.sh clean` does not touch the files listed above. It removes the
+> wrapper's own artifacts in this directory, the cloned checkout, `outputs/`
+> and `.env`.
+>
+> A `node_modules` directory you installed yourself at the checkout root is left
+> alone. Test dependencies are installed into and read from `cypress/node_modules`
+> either way, so the two never mix.
 
 ### Running a single spec file
 

--- a/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
+++ b/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
@@ -27,6 +27,7 @@
     # Paths
     qa_infra_dir: "{{ lookup('env', 'QA_INFRA_DIR') | default(playbook_dir | dirname | dirname | dirname, true) }}"
     outputs_dir: "{{ workspace_dir }}/outputs"
+    docker_context_dir: "{{ outputs_dir }}/docker-context"
     dashboard_dir: "{{ dashboard_src | default(workspace_dir + '/dashboard') }}"
     host_dashboard_dir: "{{ lookup('env', 'HOST_DASHBOARD_DIR') | default(dashboard_dir, true) }}"
     workspace_dir: "{{ lookup('env', 'WORKSPACE') | default(playbook_dir, true) }}"

--- a/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
+++ b/ansible/testing/dashboard-e2e/files/cypress.config.jenkins.ts
@@ -100,6 +100,22 @@ if (!multiReporters) {
   console.log('Reporters: cypress-multi-reporters or mocha-junit-reporter is not installed. Falling back to cypress-mochawesome-reporter. No JUnit XML will be produced.');
 }
 
+// Cypress resolves a reporter name against the project root alone, ignoring
+// NODE_PATH and nested node_modules. A root node_modules therefore breaks a
+// name `require.resolve` finds, and no JUnit XML is written at all. Hand it a
+// root relative path instead. The root comes from the entrypoint because
+// Cypress evaluates this file from its own directory.
+const projectRoot = process.env.E2E_PROJECT_ROOT || process.cwd();
+const reporterPath = (moduleName: string): string => {
+  try {
+    const relative = path.relative(projectRoot, require.resolve(moduleName));
+
+    return relative.startsWith('..') ? moduleName : relative;
+  } catch {
+    return moduleName;
+  }
+};
+
 // @cypress/grep v5+ reads its settings through the Cypress 15 `Cypress.expose`
 // API and ignores `env` entirely, so tags placed in `env` silently disable all
 // test level filtering. Cypress 11 rejects an unknown top level `expose` key,
@@ -189,7 +205,7 @@ export default defineConfig({
     allowFilteredCatalogSkip: process.env.CYPRESS_ALLOW_FILTERED_CATALOG_SKIP !== 'false',
   },
   // Jenkins reporters configuration jUnit and HTML
-  reporter:        multiReporters ? 'cypress-multi-reporters' : 'cypress-mochawesome-reporter',
+  reporter:        reporterPath(multiReporters ? 'cypress-multi-reporters' : 'cypress-mochawesome-reporter'),
   reporterOptions: multiReporters ? multiReporterOptions : { charts: false },
   e2e: {
     setupNodeEvents(on, config) {

--- a/ansible/testing/dashboard-e2e/files/cypress.sh
+++ b/ansible/testing/dashboard-e2e/files/cypress.sh
@@ -8,10 +8,60 @@ source "$(dirname "$0")/utils.sh"
 
 pwd
 
+# Undo everything this script changes in the checkout, so --dashboard-dir leaves
+# a developer's tree as found. The only place every path shares.
+_project_root="$PWD"
+# Refuse to delete paths under anything that is not a dashboard checkout.
+if [ -z "$_project_root" ] || [ ! -f "${_project_root}/cypress/package.json" ]; then
+	echo "[cypress.sh] ERROR: ${_project_root:-<empty>} is not a dashboard checkout, no cypress/package.json found."
+	exit 1
+fi
+_manifest="${_project_root}/cypress/package.json"
+# coreutils 9 also refuses to recurse across a mount point, which guards the
+# checkout root. Older rm does not know the option.
+_rm_guard=()
+if rm --help 2>&1 | grep -q 'preserve-root\[=all\]'; then
+	_rm_guard=(--preserve-root=all)
+fi
+_manifest_snapshot=""
+
+# shellcheck disable=SC2329  # invoked by the EXIT trap below
+_restore_manifest() {
+	if [ -n "$_manifest_snapshot" ] && [ -f "$_manifest_snapshot" ]; then
+		cp -p "$_manifest_snapshot" "$_manifest" 2>/dev/null || true
+		rm -f "$_manifest_snapshot" || true
+		_manifest_snapshot=""
+	fi
+}
+
+# shellcheck disable=SC2329  # invoked by the EXIT trap below
+_cleanup() {
+	_restore_manifest
+	if [ -L "${_project_root}/node_modules" ] &&
+		[ "$(readlink "${_project_root}/node_modules")" = "cypress/node_modules" ]; then
+		rm -f "${_project_root}/node_modules" || true
+	fi
+}
+trap _cleanup EXIT
+
+# The container holds cloud credentials and reporting tokens. No install needs
+# them.
+_secret_env=(
+	AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+	AZURE_AKS_SUBSCRIPTION_ID AZURE_CLIENT_ID AZURE_CLIENT_SECRET
+	CUSTOM_NODE_KEY GKE_SERVICE_ACCOUNT KUBECONFIG
+	PERCY_TOKEN QASE_AUTOMATION_TOKEN TEST_PASSWORD
+)
+_yarn_sealed() {
+	local _drop=() _v
+	for _v in "${_secret_env[@]}"; do _drop+=(-u "$_v"); done
+	env "${_drop[@]}" NODE_NO_WARNINGS=1 yarn "$@"
+}
+
 # Install test dependencies inside the container (correct platform binaries for Debian/glibc)
 echo "[cypress.sh] Installing test dependencies..."
 echo "[cypress.sh] PWD=$(pwd)"
-if ! (cd cypress && NODE_NO_WARNINGS=1 yarn install --frozen-lockfile --silent); then
+if ! (cd cypress && _yarn_sealed install --frozen-lockfile --silent); then
 	echo "[cypress.sh] ERROR: yarn install failed in $(pwd)/cypress"
 	echo "[cypress.sh] Node: $(node -v), Yarn: $(yarn --version)"
 	echo "[cypress.sh] package.json exists: $(test -f cypress/package.json && echo yes || echo no)"
@@ -19,35 +69,37 @@ if ! (cd cypress && NODE_NO_WARNINGS=1 yarn install --frozen-lockfile --silent);
 	exit 1
 fi
 # Packages this checkout does not declare, at versions pinned by the playbook.
-# grep-filter.ts requires globby and find-test-names directly and exits 1
-# without them.
 if [ -n "${MISSING_RUNTIME_DEPS:-}" ]; then
 echo "[cypress.sh] Installing packages this checkout does not declare: ${MISSING_RUNTIME_DEPS}"
-# --no-lockfile because these are additions on top of the checkout's lockfile,
-# not a change to what it pins. Unquoted on purpose: a space separated list of
-# name@version pairs that has to split into separate arguments.
+_manifest_snapshot="$(mktemp)"
+cp -p "$_manifest" "$_manifest_snapshot"
+# Unquoted on purpose, splits into separate name@version arguments.
 # shellcheck disable=SC2086
-if ! (cd cypress && NODE_NO_WARNINGS=1 yarn add --no-lockfile --silent ${MISSING_RUNTIME_DEPS}); then
+if ! (cd cypress && _yarn_sealed add --no-lockfile --ignore-scripts --silent ${MISSING_RUNTIME_DEPS}); then
 echo "[cypress.sh] ERROR: could not install ${MISSING_RUNTIME_DEPS}"
 echo "[cypress.sh] Tag filtering and JUnit reporting both need these."
 exit 1
 fi
+_restore_manifest
 fi
 
-# Point ./node_modules at the test dependencies. -n stops ln from following an
-# existing symlink and leaving a dangling link inside its target on repeat
-# --dashboard-dir runs. A real directory is left alone: that is a developer's
-# own root install, and ln would nest inside it rather than replace it.
-if [ -L node_modules ] || [ ! -e node_modules ]; then
+# Point ./node_modules at the test dependencies so anything resolving from the
+# checkout root finds them. Only an absent node_modules or a link this script
+# left is touched. A developer's own directory or link is left alone, since
+# moving it aside would strand it if the run is killed. Removed by the trap.
+if { [ ! -e node_modules ] && [ ! -L node_modules ]; } ||
+	{ [ -L node_modules ] && [ "$(readlink node_modules)" = "cypress/node_modules" ]; }; then
 	ln -sfn cypress/node_modules node_modules
 else
-	echo "[cypress.sh] node_modules is a real directory; leaving it in place (NODE_PATH still points at cypress/node_modules)."
+	echo "[cypress.sh] NOTICE: ./node_modules already exists and is not ours, so it is left untouched."
+	echo "[cypress.sh]         Test dependencies are read from cypress/node_modules either way."
 fi
 
 # Use test deps from cypress/node_modules
 export NODE_PATH="${PWD}/cypress/node_modules:${NODE_PATH:-}"
 export PATH="${PWD}/cypress/node_modules/.bin:${PATH}"
-
+# Cypress evaluates the config from its own directory, so hand it the root.
+export E2E_PROJECT_ROOT="$_project_root"
 echo "[cypress.sh] node $(node -v), kubectl $(kubectl version --client -o json 2>/dev/null | grep -o '"gitVersion":"[^"]*"' || kubectl version --client --short 2>&1 | head -1)"
 
 export FORCE_COLOR=1
@@ -144,6 +196,13 @@ if [ "$BROWSER" = chrome ] &&
 	BROWSER=electron
 fi
 
+# mocha-junit-reporter appends here rather than replacing, so a reused checkout
+# would merge every earlier run's XML into results.xml. Absolute path, anchored
+# to the checkout verified at the top.
+_junit_dir="${_project_root}/cypress/jenkins/reports/junit"
+rm -rf "${_rm_guard[@]}" -- "$_junit_dir"
+mkdir -p -- "$_junit_dir"
+
 # Run Cypress and capture the exit code
 set +e
 
@@ -157,11 +216,13 @@ set -e
 
 echo "CYPRESS EXIT CODE: $EXIT_CODE"
 
-# Merge JUnit reports inside the container (Node.js is available here)
+# Merge JUnit reports inside the container (Node.js is available here).
+# Through PATH, not `npx --no-install`: npx resolves only against
+# ./node_modules/.bin, and a developer's own root install there has no jrm.
 echo "[cypress.sh] Merging JUnit reports..."
-if ! npx --no-install jrm results.xml "cypress/jenkins/reports/junit/junit-*"; then
+if ! jrm results.xml "cypress/jenkins/reports/junit/junit-*"; then
 	echo "WARNING: jrm merge failed, so results.xml was not produced."
-	if ! npx --no-install jrm --version >/dev/null 2>&1; then
+	if ! command -v jrm >/dev/null 2>&1; then
 		echo "WARNING: junit-report-merger is not installed in this checkout, which is why the merge could not run."
 	fi
 	echo "WARNING: individual junit-*.xml files may still be available:"

--- a/ansible/testing/dashboard-e2e/files/grep-filter.ts
+++ b/ansible/testing/dashboard-e2e/files/grep-filter.ts
@@ -30,8 +30,9 @@ const requireOrExplain = (moduleName: string): unknown => {
     if ((e as NodeJS.ErrnoException | undefined)?.code === 'MODULE_NOT_FOUND') {
       console.error(`[grep-filter] '${ moduleName }' is not installed in this checkout.`);
       console.error('[grep-filter] Spec pre-selection needs it, so tag filtering cannot run.');
-      console.error('[grep-filter] Branches from release-2.14 onwards carry it in cypress/package.json;');
-      console.error('[grep-filter] the clone path also overlays it from dashboard_overlay_branch.');
+      console.error('[grep-filter] release-2.15 and newer declare it in cypress/package.json.');
+      console.error('[grep-filter] The clone path supplies it on older branches; a local');
+      console.error('[grep-filter] checkout is never written to, so --dashboard-dir needs 2.15+.');
       process.exit(1);
     }
     throw e;

--- a/ansible/testing/dashboard-e2e/run.sh
+++ b/ansible/testing/dashboard-e2e/run.sh
@@ -478,6 +478,25 @@ if [ -n "${DASHBOARD_DIR:-}" ]; then
 		exit 2
 	fi
 	unset _missing _f
+
+	# release-2.14 carries the cypress/ manifests but not the reporting and tag
+	# filtering packages. The clone path installs what a branch leaves out; a
+	# local checkout is never written to, so it has to declare them itself.
+	_missing_deps=""
+	for _p in cypress-multi-reporters mocha-junit-reporter junit-report-merger find-test-names globby; do
+		grep -q "\"${_p}\"[[:space:]]*:" "${DASHBOARD_DIR}/cypress/package.json" ||
+			_missing_deps="${_missing_deps} ${_p}"
+	done
+	if [ -n "${_missing_deps}" ]; then
+		echo "ERROR: --dashboard-dir checkout does not declare:${_missing_deps}" >&2
+		echo "       These carry the JUnit reporting and the tag filtering the run" >&2
+		echo "       needs. They are declared from release-2.15 onwards, so" >&2
+		echo "       --dashboard-dir requires a release-2.15 or newer checkout." >&2
+		echo "       Older branches still run through the clone path: drop" >&2
+		echo "       --dashboard-dir and set dashboard_branch." >&2
+		exit 2
+	fi
+	unset _missing_deps _p
 fi
 
 echo "[run] Using ${RUNTIME} (socket: ${SOCKET})"

--- a/ansible/testing/dashboard-e2e/tasks/run-tests.yml
+++ b/ansible/testing/dashboard-e2e/tasks/run-tests.yml
@@ -45,6 +45,23 @@
     fi
   changed_when: false
 
+# cypress.sh points ./node_modules at cypress/node_modules. Left behind in a
+# local checkout it would send a later root `yarn install` into the test tree.
+# Only the link this run created is removed, never a developer's own directory.
+- name: Stat the node_modules link in the checkout
+  ansible.builtin.stat:
+    path: "{{ dashboard_dir }}/node_modules"
+    follow: false
+  register: _node_modules_link
+
+- name: Remove the node_modules link the run created
+  ansible.builtin.file:
+    path: "{{ dashboard_dir }}/node_modules"
+    state: absent
+  when:
+    - _node_modules_link.stat.islnk | default(false)
+    - _node_modules_link.stat.lnk_target | default('') == 'cypress/node_modules'
+
 - name: Set test exit code
   ansible.builtin.set_fact:
     cypress_exit_code: "{{ cypress_result.rc | default(1) }}"

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -92,6 +92,28 @@
   loop_control:
     label: "{{ item.dest }}"
 
+# Dockerfile.ci copies one file, imported_config, and reads nothing else from
+# the context. Building from the checkout would ship the whole working tree,
+# including cypress/node_modules, and would need a .dockerignore written into a
+# directory that is not ours to edit.
+- name: Check the Docker build context path before resetting it
+  ansible.builtin.assert:
+    that:
+      - docker_context_dir is defined
+      - docker_context_dir | length > 0
+      - docker_context_dir is search('/outputs/docker-context$')
+    fail_msg: >-
+      docker_context_dir resolved to '{{ docker_context_dir | default("") }}',
+      which is not the expected outputs/docker-context path. Refusing to delete it.
+
+- name: Reset the Docker build context
+  ansible.builtin.file:
+    path: "{{ docker_context_dir }}"
+    state: "{{ item }}"
+  loop:
+    - absent
+    - directory
+
 # A checkout that carries its own cypress/package.json is self consistent and
 # keeps its own Cypress. Overlaying master's manifests onto it forces a Cypress
 # major the branch's specs were never written for, which surfaces as a suite
@@ -330,7 +352,7 @@
     - name: Write imported_config for Docker
       ansible.builtin.copy:
         content: "{{ import_kubeconfig_b64.content | b64decode }}"
-        dest: "{{ dashboard_dir }}/imported_config"
+        dest: "{{ docker_context_dir }}/imported_config"
         mode: "0600"
       when: _kubeconfig_file.stat.exists
 
@@ -477,7 +499,23 @@
       versions at container start. grep-filter.ts requires globby and
       find-test-names directly and exits 1 without them, and jrm cannot merge
       the JUnit XML.
-  when: _missing_runtime_deps | length > 0
+  when:
+    - dashboard_src is not defined
+    - _missing_runtime_deps | length > 0
+
+# Filling a gap writes to cypress/package.json, which a clone can absorb because
+# it is thrown away. A local checkout is the developer's own tree, so refuse.
+- name: Assert a local checkout declares the reporting packages
+  ansible.builtin.assert:
+    that: _missing_runtime_deps | length == 0
+    success_msg: "the checkout declares the reporting and tag filtering packages"
+    fail_msg: >-
+      This checkout does not declare {{ _missing_runtime_deps | join(', ') }},
+      which carry the JUnit reporting and the tag filtering the run needs. They
+      are declared from release-2.15 onwards, so --dashboard-dir requires a
+      release-2.15 or newer checkout. Older branches still run through the clone
+      path: drop --dashboard-dir and set dashboard_branch.
+  when: dashboard_src is defined
 
 - name: Assert the checkout can run Cypress at all
   ansible.builtin.assert:
@@ -497,18 +535,6 @@
       Cypress={{ cypress_version }}, Node={{ nodejs_version }},
       Chrome={{ chrome_version }}
 
-- name: Write .dockerignore for build context
-  ansible.builtin.copy:
-    content: |
-      .git
-      node_modules
-      cypress/downloads
-      cypress/screenshots
-      cypress/videos
-      cypress/reports
-    dest: "{{ dashboard_dir }}/.dockerignore"
-    mode: "0644"
-
 - name: Build dashboard-test Docker image
   ansible.builtin.command:
     argv:
@@ -526,7 +552,7 @@
       - "CYPRESS_VERSION={{ cypress_version }}"
       - --build-arg
       - "CHROME_VERSION={{ chrome_version }}"
-      - "{{ dashboard_dir }}"
+      - "{{ docker_context_dir }}"
   changed_when: true
 
 # The docker build output is only shown when the build fails, so a successful


### PR DESCRIPTION
Running with `--dashboard-dir` against a checkout that has its own root `node_modules` failed in three ways at once, none of which pointed at the cause.

`results.xml` came out empty, because the reporter never loaded:

```
Error loading the reporter: cypress-multi-reporters
Cannot find module '/e2e/node_modules/cypress-multi-reporters'
```

Cypress resolves a reporter against the project root alone. It ignores `NODE_PATH` and does not walk nested `node_modules`, so a real root install makes the reporter unloadable and no JUnit XML is written at all.

The run also modified a tracked file. Installing the packages a branch does not declare writes `cypress/package.json` and leaves the lockfile beside it alone, so the next install rejects a manifest the lockfile does not pin and a second run refuses to start.

Jenkins never saw any of this. A fresh clone has no root `node_modules` and is used once.

## The cause

The run assumed a checkout it owns. It read and wrote paths that belong to the developer: the checkout root for module resolution, a tracked manifest, a `node_modules` link, the Docker build context, and a report directory that is never cleared.

## The fix

- Resolve the reporter and `jrm` through paths the run controls, not the checkout root. `jrm` moves from `npx --no-install`, which resolves only against `./node_modules/.bin`, to `PATH`.
- Snapshot `cypress/package.json` and put it back after installing packages a branch does not declare. Restored on success, on failure and on `SIGTERM`.
- Remove the `node_modules` link the run creates. A developer's own directory or link is never touched.
- Build the test image from a context of its own. `Dockerfile.ci` reads one file, and building from the checkout shipped the whole working tree.
- Clear the JUnit directory at the start of a run. `mocha-junit-reporter` appends, so a reused checkout merged every earlier run's XML.
- Anchor every path the run deletes to a directory verified to hold `cypress/package.json`.
- Install without lifecycle scripts and with the cloud credentials, tokens and `KUBECONFIG` removed from the environment.
- Require `release-2.15` or newer for `--dashboard-dir`, checked before anything is provisioned. Older branches need packages installed into the checkout, which is what a local run must not do. They still run through the clone path.
- Document what a run leaves behind and how to clear it.

The clone path is unchanged.

## Testing

Fifteen local runs against real infrastructure, across `release-2.14`, `release-2.15` and `master`, four root `node_modules` states (absent, a real install, a stale cross branch install, a leftover link) and both execution paths. Each was checked afterwards for a `cypress/package.json` sha that had not moved and for a link left behind.

The state that breaks is a stale cross branch tree, which is what switching branches leaves. A full root install on 2.15 or master happens to satisfy Cypress, because those root manifests carry the reporters, so both variants were run per branch. Twelve component probes covered what a run cannot reach on demand, including the manifest restored on a failed install and on `SIGTERM`, and a non-checkout directory refused.

## Verified on Jenkins

Eight builds, three branches, both `create_initial_clusters` paths. No reporter error, no false positive from the new path guard, and every build recorded its results.

| Build | Branch | Result |
|-------|--------|--------|
| 407 | master | SUCCESS, 53 of 53, 12 JUnit files merged |
| 399 | release-2.15 | SUCCESS, `create_initial_clusters: true` |
| 408 | release-2.14 | 52 of 53, 11 JUnit files merged |

The single failure on `release-2.14` is a spec bug on that branch, not a pipeline one. `get-support.spec.ts` asserts a standard user cannot see the Support link, without `@noPrime`, and those runs used `rancher-prime`. The spec was deleted on `release-2.15` and `master`.
