### PR TITLE
[Dashboard] - Install the test dependencies only from the lockfile

### DIFF
--- a/ansible/testing/dashboard-e2e/README.md
+++ b/ansible/testing/dashboard-e2e/README.md
@@ -415,22 +415,19 @@ This is useful when:
 > are responsible for ensuring that their local code branch is compatible with the targeted
 > `rancher_helm_repo` and `rancher_image_tag`, otherwise tests may fail with unexpected UI errors.
 
-> **Branch requirement:** `--dashboard-dir` requires a `release-2.15` or newer
+> **Branch requirement:** `--dashboard-dir` requires a `release-2.14` or newer
 > checkout. The checkout has to carry its test dependencies in
 > `cypress/package.json` and `cypress/yarn.lock`, and those manifests have to
-> declare the reporting and tag filtering packages: `cypress-multi-reporters`,
-> `mocha-junit-reporter`, `junit-report-merger`, `find-test-names` and `globby`.
-> `release-2.15` was the first branch to declare all of them. `release-2.14`
-> carries the manifests but not those packages, and `release-2.13` and older
-> keep the test dependencies in the root `package.json` altogether.
+> declare the packages the run loads: `cypress`, `@cypress/grep`, the two
+> reporters, `junit-report-merger`, `find-test-names` and `globby`.
+> `release-2.13` and older keep the test dependencies in the root
+> `package.json` altogether.
 >
-> The clone path fills either gap for you, by overlaying the manifests from
-> `dashboard_overlay_branch` and by installing whatever a branch leaves out. It
-> can do that because the clone is thrown away after the run. Your own checkout
-> is not, so nothing is ever written into it and the run refuses to start
-> instead. `run.sh` rejects such a directory up front, before any infrastructure
-> is provisioned. To test an older branch, drop `--dashboard-dir` and set
-> `dashboard_branch`.
+> Everything the run loads is installed from `cypress/yarn.lock` and nothing is
+> added at run time, so a gap cannot be filled in later. `run.sh` rejects such a
+> directory up front, before any infrastructure is provisioned. To test an older
+> branch, drop `--dashboard-dir` and set `dashboard_branch`; the clone path
+> overlays the manifests from `dashboard_overlay_branch`.
 
 > **Cypress version:** the checkout supplies its own [branch
 > contract](#the-branch-contract), so `cypress_version` is read from its
@@ -456,12 +453,10 @@ This is useful when:
 > Nothing else in your checkout is modified. The imported cluster kubeconfig is
 > written to this playbook's `outputs/` rather than into your tree, and the
 > `node_modules` link the run creates at the checkout root is removed when the
-> run finishes. Branches that do not declare the reporting and tag filtering
-> packages get them installed into `cypress/node_modules` at container start,
-> and `cypress/package.json` is put back afterwards so it stays in step with
-> `cypress/yarn.lock`. That install runs with lifecycle scripts disabled and
-> with the cloud credentials and reporting tokens removed from its environment,
-> since it needs neither.
+> run finishes. Test dependencies are installed from `cypress/yarn.lock` into
+> `cypress/node_modules`, with the cloud credentials and reporting tokens
+> removed from the install's environment. No manifest in your tree is written
+> to.
 >
 > `./run.sh clean` does not touch the files listed above. It removes the
 > wrapper's own artifacts in this directory, the cloned checkout, `outputs/`

--- a/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
+++ b/ansible/testing/dashboard-e2e/dashboard-e2e-playbook.yml
@@ -50,18 +50,17 @@
     executor_tag: "{{ lookup('env', 'EXECUTOR_NUMBER') | default('0', true) }}"
 
     # Packages cypress.sh and grep-filter.ts load at run time inside the
-    # container, installed only when the checkout does not declare them.
-    # Versions are exact because everything else here is pinned, from the base
-    # image digest to yarn.lock.
+    # container. Every checkout declares them, so they are installed from
+    # cypress/yarn.lock and nothing is added at run time.
     _runtime_deps:
-      - { name: cypress, version: "" }
-      - { name: "@cypress/grep", version: "" }
-      - { name: cypress-mochawesome-reporter, version: 3.8.2 }
-      - { name: cypress-multi-reporters, version: 1.6.4 }
-      - { name: mocha-junit-reporter, version: 2.2.1 }
-      - { name: junit-report-merger, version: 9.0.3 }
-      - { name: find-test-names, version: 1.29.19 }
-      - { name: globby, version: 11.1.0 }
+      - cypress
+      - "@cypress/grep"
+      - cypress-mochawesome-reporter
+      - cypress-multi-reporters
+      - mocha-junit-reporter
+      - junit-report-merger
+      - find-test-names
+      - globby
 
   pre_tasks:
     - name: Create outputs directory

--- a/ansible/testing/dashboard-e2e/files/cypress.sh
+++ b/ansible/testing/dashboard-e2e/files/cypress.sh
@@ -16,27 +16,15 @@ if [ -z "$_project_root" ] || [ ! -f "${_project_root}/cypress/package.json" ]; 
 	echo "[cypress.sh] ERROR: ${_project_root:-<empty>} is not a dashboard checkout, no cypress/package.json found."
 	exit 1
 fi
-_manifest="${_project_root}/cypress/package.json"
 # coreutils 9 also refuses to recurse across a mount point, which guards the
 # checkout root. Older rm does not know the option.
 _rm_guard=()
 if rm --help 2>&1 | grep -q 'preserve-root\[=all\]'; then
 	_rm_guard=(--preserve-root=all)
 fi
-_manifest_snapshot=""
-
-# shellcheck disable=SC2329  # invoked by the EXIT trap below
-_restore_manifest() {
-	if [ -n "$_manifest_snapshot" ] && [ -f "$_manifest_snapshot" ]; then
-		cp -p "$_manifest_snapshot" "$_manifest" 2>/dev/null || true
-		rm -f "$_manifest_snapshot" || true
-		_manifest_snapshot=""
-	fi
-}
 
 # shellcheck disable=SC2329  # invoked by the EXIT trap below
 _cleanup() {
-	_restore_manifest
 	if [ -L "${_project_root}/node_modules" ] &&
 		[ "$(readlink "${_project_root}/node_modules")" = "cypress/node_modules" ]; then
 		rm -f "${_project_root}/node_modules" || true
@@ -67,20 +55,6 @@ if ! (cd cypress && _yarn_sealed install --frozen-lockfile --silent); then
 	echo "[cypress.sh] package.json exists: $(test -f cypress/package.json && echo yes || echo no)"
 	echo "[cypress.sh] yarn.lock exists: $(test -f cypress/yarn.lock && echo yes || echo no)"
 	exit 1
-fi
-# Packages this checkout does not declare, at versions pinned by the playbook.
-if [ -n "${MISSING_RUNTIME_DEPS:-}" ]; then
-echo "[cypress.sh] Installing packages this checkout does not declare: ${MISSING_RUNTIME_DEPS}"
-_manifest_snapshot="$(mktemp)"
-cp -p "$_manifest" "$_manifest_snapshot"
-# Unquoted on purpose, splits into separate name@version arguments.
-# shellcheck disable=SC2086
-if ! (cd cypress && _yarn_sealed add --no-lockfile --ignore-scripts --silent ${MISSING_RUNTIME_DEPS}); then
-echo "[cypress.sh] ERROR: could not install ${MISSING_RUNTIME_DEPS}"
-echo "[cypress.sh] Tag filtering and JUnit reporting both need these."
-exit 1
-fi
-_restore_manifest
 fi
 
 # Point ./node_modules at the test dependencies so anything resolving from the

--- a/ansible/testing/dashboard-e2e/files/grep-filter.ts
+++ b/ansible/testing/dashboard-e2e/files/grep-filter.ts
@@ -30,9 +30,8 @@ const requireOrExplain = (moduleName: string): unknown => {
     if ((e as NodeJS.ErrnoException | undefined)?.code === 'MODULE_NOT_FOUND') {
       console.error(`[grep-filter] '${ moduleName }' is not installed in this checkout.`);
       console.error('[grep-filter] Spec pre-selection needs it, so tag filtering cannot run.');
-      console.error('[grep-filter] release-2.15 and newer declare it in cypress/package.json.');
-      console.error('[grep-filter] The clone path supplies it on older branches; a local');
-      console.error('[grep-filter] checkout is never written to, so --dashboard-dir needs 2.15+.');
+      console.error('[grep-filter] It is installed from cypress/yarn.lock, so the checkout has');
+      console.error('[grep-filter] to declare it. release-2.14 and newer do.');
       process.exit(1);
     }
     throw e;

--- a/ansible/testing/dashboard-e2e/run.sh
+++ b/ansible/testing/dashboard-e2e/run.sh
@@ -479,9 +479,9 @@ if [ -n "${DASHBOARD_DIR:-}" ]; then
 	fi
 	unset _missing _f
 
-	# release-2.14 carries the cypress/ manifests but not the reporting and tag
-	# filtering packages. The clone path installs what a branch leaves out; a
-	# local checkout is never written to, so it has to declare them itself.
+	# Everything the run loads comes from cypress/yarn.lock and nothing is added
+	# at run time, so a checkout that does not declare one cannot be filled in
+	# later. release-2.14 and newer declare all of them.
 	_missing_deps=""
 	for _p in cypress-multi-reporters mocha-junit-reporter junit-report-merger find-test-names globby; do
 		grep -q "\"${_p}\"[[:space:]]*:" "${DASHBOARD_DIR}/cypress/package.json" ||
@@ -490,10 +490,11 @@ if [ -n "${DASHBOARD_DIR:-}" ]; then
 	if [ -n "${_missing_deps}" ]; then
 		echo "ERROR: --dashboard-dir checkout does not declare:${_missing_deps}" >&2
 		echo "       These carry the JUnit reporting and the tag filtering the run" >&2
-		echo "       needs. They are declared from release-2.15 onwards, so" >&2
-		echo "       --dashboard-dir requires a release-2.15 or newer checkout." >&2
-		echo "       Older branches still run through the clone path: drop" >&2
-		echo "       --dashboard-dir and set dashboard_branch." >&2
+		echo "       needs, and they are installed from cypress/yarn.lock, so a" >&2
+		echo "       checkout that does not declare them cannot filter or report." >&2
+		echo "       release-2.14 and newer declare all of them. To test an older" >&2
+		echo "       branch, drop --dashboard-dir and set dashboard_branch; the" >&2
+		echo "       clone path overlays the manifests from a newer branch." >&2
 		exit 2
 	fi
 	unset _missing_deps _p

--- a/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
+++ b/ansible/testing/dashboard-e2e/tasks/setup-test-env.yml
@@ -474,59 +474,27 @@
     msg: "Cypress {{ cypress_version }} for {{ target_branch | default('the local checkout', true) }}"
 
 # cypress.sh and grep-filter.ts resolve these at run time inside the container.
-# A checkout that keeps its own Cypress may predate some, so name the gap and
-# let cypress.sh install them rather than fail a run that can still report.
+# They come from cypress/yarn.lock and nothing is added at run time, so a
+# checkout that does not declare one cannot be filled in later.
 - name: Read what the checkout declares
   ansible.builtin.set_fact:
-    _declared: "{{ _decl }}"
-    _missing_runtime_deps: "{{ _runtime_deps | rejectattr('name', 'in', _decl) | map(attribute='name') | list }}"
-    # cypress and @cypress/grep carry no version, because their major has to
-    # match the checkout. A missing one is a hard failure, not an install.
-    _missing_deps_pinned: >-
-      {{ _runtime_deps | rejectattr('name', 'in', _decl) | rejectattr('version', 'eq', '')
-         | map(attribute='name') | zip(_runtime_deps | rejectattr('name', 'in', _decl)
-         | rejectattr('version', 'eq', '') | map(attribute='version'))
-         | map('join', '@') | join(' ') }}
+    _missing_runtime_deps: "{{ _runtime_deps | difference(_decl) }}"
   vars:
     _m: "{{ (_cypress_manifest.content | b64decode | from_json) if (_cypress_manifest.content | default('') | length) > 0 else {} }}"
     _decl: "{{ ((_m.dependencies | default({})) | combine(_m.devDependencies | default({}))) | list }}"
 
-- name: Report packages the checkout does not declare
-  ansible.builtin.debug:
-    msg: >-
-      {{ target_branch | default('the local checkout', true) }} does not declare
-      {{ _missing_runtime_deps | join(', ') }}. cypress.sh installs the pinned
-      versions at container start. grep-filter.ts requires globby and
-      find-test-names directly and exits 1 without them, and jrm cannot merge
-      the JUnit XML.
-  when:
-    - dashboard_src is not defined
-    - _missing_runtime_deps | length > 0
-
-# Filling a gap writes to cypress/package.json, which a clone can absorb because
-# it is thrown away. A local checkout is the developer's own tree, so refuse.
-- name: Assert a local checkout declares the reporting packages
+- name: Assert the checkout declares what the run loads
   ansible.builtin.assert:
     that: _missing_runtime_deps | length == 0
-    success_msg: "the checkout declares the reporting and tag filtering packages"
+    success_msg: "the checkout declares the packages the run loads"
     fail_msg: >-
-      This checkout does not declare {{ _missing_runtime_deps | join(', ') }},
-      which carry the JUnit reporting and the tag filtering the run needs. They
-      are declared from release-2.15 onwards, so --dashboard-dir requires a
-      release-2.15 or newer checkout. Older branches still run through the clone
-      path: drop --dashboard-dir and set dashboard_branch.
-  when: dashboard_src is defined
-
-- name: Assert the checkout can run Cypress at all
-  ansible.builtin.assert:
-    that: "'cypress' in _declared and '@cypress/grep' in _declared"
-    success_msg: "the checkout declares cypress and @cypress/grep"
-    fail_msg: >-
-      This checkout declares no cypress or no @cypress/grep, so there is
-      nothing to run and no way to filter by tag.
-      {{ 'The dependency overlay is skipped for local checkouts, so the directory passed to --dashboard-dir has to supply them.'
+      This checkout does not declare {{ _missing_runtime_deps | sort | join(', ') }}.
+      Cypress, the reporters and the tag filtering packages are installed from
+      cypress/yarn.lock, so a checkout that does not declare one has no way to
+      run, filter or report. release-2.14 and newer declare all of them.
+      {{ 'The directory passed to --dashboard-dir has to supply them, so use a newer branch or drop --dashboard-dir.'
          if dashboard_src is defined
-         else 'The overlay from ' ~ (dashboard_overlay_branch | default('master', true)) ~ ' did not supply them.' }}
+         else 'Older branches get them from the overlay, which did not supply them here.' }}
 
 - name: Show Docker build args
   ansible.builtin.debug:

--- a/ansible/testing/dashboard-e2e/templates/env.j2
+++ b/ansible/testing/dashboard-e2e/templates/env.j2
@@ -40,7 +40,3 @@ CYPRESS_ALLOW_FILTERED_CATALOG_SKIP={{ allow_filtered_catalog_skip | default(tru
 CYPRESS_BROWSER={{ cypress_browser | default('chrome') }}
 RANCHER_IMAGE_TAG={{ rancher_image_tag_resolved | default(rancher_image_tag) }}
 RANCHER_VERSION={{ rancher_version | default('') }}
-
-# Packages the checkout does not declare, installed by cypress.sh at container
-# start. Space separated name@version pairs, empty when none are missing.
-MISSING_RUNTIME_DEPS={{ _missing_deps_pinned | default('') }}


### PR DESCRIPTION
Test dependencies could enter a run two ways: from `cypress/yarn.lock`, or added at container start for a branch that did not declare them. The second way had no lockfile, so those packages and their dependencies resolved fresh on every run, and the install wrote to a tracked manifest.

`release-2.14` was the only branch that needed it, and rancher/dashboard#18730 has it declaring them itself.

## The change

`yarn install --frozen-lockfile` is now the only way test dependencies enter a run. A checkout that does not declare what the run loads is refused before anything is provisioned, by `run.sh` and by the playbook.

That removes the run time install, the manifest snapshot and restore that went with it, and the `MISSING_RUNTIME_DEPS` plumbing behind them.

## Testing

Two builds on `release-2.14`, the branch this affects, one with `create_initial_clusters` false and one true. Both 52 of 53, the same result and the same 11 merged JUnit files as the run before this change. The one failure is a spec issue on that branch, unrelated.

Neither log mentions installing anything the checkout does not declare, and the new assertion passed on both.
