### PR TITLE
fix(machineconfig): fix AWS credential keys and auto-detect SG IDs

### DIFF
--- a/tofu/rancher/cluster/README.md
+++ b/tofu/rancher/cluster/README.md
@@ -65,6 +65,8 @@ node_config = {
 
   aws_instance_type = "t3a.2xlarge"
   aws_security_group = ["rancher-nodes"] 
+  # When passing security group IDs (sg-*), set aws_security_group_readonly = true
+  # so docker-machine uses them as-is instead of trying to create new groups.
 
   aws_subnet = "subnet-123"
   aws_availability_zone = "b"

--- a/tofu/rancher/machineconfig/main.tf
+++ b/tofu/rancher/machineconfig/main.tf
@@ -16,7 +16,11 @@ resource "rancher2_machine_config_v2" "rancher2_machine_config_v2" {
       subnet_id                  = try(var.node_config.aws_subnet, null)
       vpc_id                     = try(var.node_config.aws_vpc, null)
       zone                       = try(var.node_config.aws_availability_zone, null)
-      access_key                 = try(var.node_config.access_key, null)
+      access_key                 = try(var.node_config.aws_access_key, null)
+      # When security groups are given as IDs (sg-*), docker-machine must be told
+      # to use them as-is rather than treating them as names of groups to create.
+      # Auto-detect sg-* IDs unless aws_security_group_readonly is set explicitly.
+      security_group_readonly    = try(var.node_config.aws_security_group_readonly, anytrue([for sg in try(var.node_config.aws_security_group, []) : can(regex("^sg-[0-9a-f]+$", tostring(sg)))]) ? true : null)
       block_duration_minutes     = try(var.node_config.aws_block_duration_minutes, null)
       device_name                = try(var.node_config.aws_device_name, null)
       encrypt_ebs_volume         = try(var.node_config.aws_encrypt_ebs_volume, null)
@@ -33,8 +37,7 @@ resource "rancher2_machine_config_v2" "rancher2_machine_config_v2" {
       request_spot_instance      = try(var.node_config.aws_request_spot_instance, null)
       retries                    = try(var.node_config.aws_retries, null)
       root_size                  = try(var.node_config.aws_volume_size, null)
-      secret_key                 = try(var.node_config.secret_key, null)
-      security_group_readonly    = try(var.node_config.aws_security_group_readonly, null)
+      secret_key                 = try(var.node_config.aws_secret_key, null)
       session_token              = try(var.node_config.aws_session_token, null)
       spot_price                 = try(var.node_config.aws_spot_price, null)
       ssh_user                   = try(var.node_config.aws_ssh_user, null)


### PR DESCRIPTION
## Summary

Fixes two bugs in the `rancher/cluster` module's `machineconfig` submodule that prevented downstream clusters from provisioning on AWS.

## Root causes

### 1. AWS credential key mismatch

The `machineconfig` submodule read AWS credentials under unprefixed keys (`access_key`/`secret_key`) while the `cloudcredential` submodule and the README sample use the prefixed names (`aws_access_key`/`aws_secret_key`). Since the cluster module passes a single `node_config` object to both, the machine config (node template) silently received `null` for both credential fields.

### 2. Security group IDs treated as names (the primary blocker)

When security groups are passed as **IDs** (`sg-*`), the docker-machine amazonec2 driver treats them as **names** of groups to create. AWS rejects this:

```
Error: InvalidParameterValue: Value (sg-08e8243a8cfbea8a0) for parameter GroupName is invalid.
Group names may not be in the format sg-*.
```

No EC2 instances were ever launched — every node provision job failed immediately, and `tofu apply` timed out waiting for nodes that never came up.

## Changes

- **`tofu/rancher/machineconfig/main.tf`**: Fixed credential keys to `aws_access_key`/`aws_secret_key` (matching `cloudcredential` and the README)
- **`tofu/rancher/machineconfig/main.tf`**: Auto-set `security_group_readonly = true` when `sg-*` IDs are detected, so docker-machine uses existing groups as-is instead of trying to create new ones
- **`tofu/rancher/cluster/README.md`**: Documented the SG name vs ID behavior

## Verification

Reproduced the failure, applied the fix, and ran `tofu apply` end-to-end:
- All 3 EC2 instances launched successfully
- Provision pod logs confirmed: `Found existing security group (qa_default_ipv4) in vpc-bfccf4d7`
- Cluster reached `state=active` (`Apply complete! Resources: 4 added`)

## Test plan

- [x] `tofu validate` passes
- [x] `tofu apply` provisions a working downstream cluster (3 nodes, active state)
- [x] `tofu destroy` cleans up all resources